### PR TITLE
add markdownlint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
   hooks:
   - id: isort
     args: ["--profile", "black", "--filter-files"]
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.27.1
+  hooks:
+  - id: markdownlint


### PR DESCRIPTION
we don't need a GitHub superliner. That's too complex. I was wrong about the thing that markdownlint cant be individually added.