### PR TITLE
Measuring code coverage, and split ci workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,15 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   push:
@@ -18,10 +18,13 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-    - name: Use Python ${{ matrix.node-version }}
+    - name: Use Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install -r requirements-dev.txt
-    - run: pre-commit run --all-files
-    - run: pytest
+    - run: pytest --cov=./notion-client --cov-report=xml
+    - uses: codecov/codecov-action@v1
+      with:
+        env_vars: PYTHON
+        fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install -r requirements-dev.txt
-    - run: pytest --cov=./notion-client --cov-report=xml
+    - run: pytest --cov=./notion_client --cov-report=xml
     - uses: codecov/codecov-action@v1
       with:
         env_vars: PYTHON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install -r requirements-dev.txt
-    - run: pytest --cov=./notion_client --cov-report=xml
+    - run: pytest
     - uses: codecov/codecov-action@v1
       with:
         env_vars: PYTHON

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -e .
+coverage
 pre-commit
 pytest
-tox
-coverage
 pytest-cov
+tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@
 pre-commit
 pytest
 tox
+coverage
+pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+minversion = 6.0
+addopts = --cov=./notion_client --cov-report=term-missing --cov-report=xml


### PR DESCRIPTION
We need to measure coverage if we want to walk the path of #8. And as discussed in https://github.com/ramnes/notion-sdk-py/pull/13#issuecomment-841625595, ci workflow split is implemented.