### PR TITLE
Fix variable name mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ These options are all keys in the single constructor parameter.
 |--------|---------------|---------|-------------|
 | `auth` | `None` | `string` | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request. |
 | `log_level` | `logging.WARNING` | `int` | Verbosity of logs the instance will produce. By default, logs are written to `stdout`.
-| `timeoutMs` | `60_000` | `int` | Number of milliseconds to wait before emitting a `RequestTimeoutError` |
+| `timeout_ms` | `60_000` | `int` | Number of milliseconds to wait before emitting a `RequestTimeoutError` |
 | `base_url` | `"https://api.notion.com"` | `string` | The root URL for sending API requests. This can be changed to test with a mock server. |
 | `logger` | Log to console | `logging.Logger` | A custom logger. |
 <!-- markdownlint-enable -->


### PR DESCRIPTION
timeoutMs -> timeout_ms

the code is already correct

https://github.com/ramnes/notion-sdk-py/blob/1e676511db7a0c6627d5cf8c3ba7b1940118e043/notion_client/client.py#L21