### PR TITLE
Docs site with mkdocs + docstrings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing Guidelines
+
+If you are a first time contributor, start by reading [this fantastic guide](https://opensource.guide/how-to-contribute/).
+
+1. Read the docs
+      - [notion-sdk-py](https://github.com/ramnes/notion-sdk-py)
+      - [Notion API Reference](https://developers.notion.com/reference/intro)
+      - [httpx](https://www.python-httpx.org/)
+
+2. System Requirements
+      - [git](https://git-scm.com/)
+      - [python](https://www.python.org/)
+      - [pip](https://pip.pypa.io/en/stable/quickstart/)
+
+3. Fork the repository and clone it.
+Checkout a new feature branch from `main`.
+This [guide](https://docs.github.com/en/github/getting-started-with-github/quickstart/fork-a-repo)
+will be really helpful if you are a newbie.
+
+4. Install dependencies inside a virtual environment.
+
+    ```shell
+    python -m venv .venv && source .venv/bin/activate
+    pip install -r requirements-dev.txt
+    ```
+
+5. Install [pre-commit](https://pre-commit.com/) hooks.
+
+    ```shell
+    pre-commit install
+    ```
+
+6. Follow the code style enforced by tools such as black, isort, flake, mypy.
+For markdown files, markdownlint must be followed.
+
+7. Tests must pass. If you are adding features write tests.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+      - run: pip install -r requirements-docs.txt pytest pytest-cov
+      - run: pytest
+      - run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Publish docs
+        run: mkdocs gh-deploy
+        

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
     additional_dependencies: ["httpx"]
     args: []
     files: "^notion_client\/.*"
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 6.0.0
+  hooks:
+  - id: pydocstyle
+    files: "^notion_client\/.*"
+  

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,12 @@
+<!-- markdownlint-disable -->
+* Home
+    * [Overview](index.md)
+    * [Quick Start](quick_start.md)
+    * [License](license.md)
+* Reference
+    * [Client](reference/client.md)
+    * [API Endpoints](reference/api_endpoints.md)
+    * [Errors](reference/errors.md)
+* Development
+    * [Coverage Report](coverage.md)
+    * [Contributing Guidelines](contributing/contributing.md)

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -1,0 +1,22 @@
+"""Generate virtual files for mkdocs."""
+
+import mkdocs_gen_files
+
+
+def docs_stub(module_name):
+    return f"::: notion_client.{module_name}\
+        \n\trendering:\n\t\tshow_root_heading: true\n\t\tshow_source: false"
+
+
+virtual_files = {
+    "index.md": "--8<-- 'README.md'",
+    "license.md": "```text\n--8<-- 'LICENSE'\n```",
+    "reference/api_endpoints.md": docs_stub("api_endpoints"),
+    "reference/client.md": docs_stub("client"),
+    "reference/errors.md": docs_stub("errors"),
+    "contributing/contributing.md": "--8<-- '.github/CONTRIBUTING.md'",
+}
+
+for file_name, content in virtual_files.items():
+    with mkdocs_gen_files.open(file_name, "w") as file:
+        print(content, file=file)

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,0 +1,114 @@
+# Quick Start
+
+Get started with notion-sdk-py in just 5 minutes!
+
+## Setup
+
+### Pre requisites
+
+- Make sure you have `python` and `pip` properly installed in your system.
+
+    ```shell
+    python --version
+    pip --version
+    ```
+
+- Create a new directory and move into it to follow along with this tutorial.
+
+    ```shell
+    mkdir learn-notion-sdk-py && cd learn-notion-sdk-py
+    ```
+
+### Installation
+
+- Create a virtual environment and activate it.
+
+    ```shell
+    python -m venv .venv && source .venv/bin/activate
+    ```
+
+- Install `notion-sdk-py` using `pip`
+
+    ```shell
+    pip install --upgrade notion-client
+    ```
+
+### Create integration
+
+- Go to [notion.so/my-integrations](https://www.notion.so/my-integrations)
+to create an integration. Copy the token given by Notion.
+
+- Make it available in your environment:
+
+    ```shell
+    export NOTION_TOKEN=secret_abcd12345
+    ```
+
+!!! tip
+    Don't forget that `export` only puts the variable in the environment of the
+    current shell.
+    If you don't want to redo this step for every new shell,
+    add the line in your shell configuration
+    or use a configuration library like [dotenv](https://github.com/theskumar/python-dotenv).
+
+## Play
+
+Copy paste the code, and have fun tweaking it.
+
+### Initialize the notion client
+
+```python
+from pprint import pprint
+from notion_client import Client
+import settings
+
+notion = Client(auth=settings.NOTION_TOKEN)
+```
+
+### Get all users
+
+Let us fetch the list of users in the scope of our integration.
+
+```python
+users = notion.users.list()
+# print(users)
+
+for user in users.get("results"):
+    name, user_type = user["name"], user["type"]
+    is_bot = user["type"] == "bot"
+    print(f"{name} is a {user_type} {'😅' if is_bot else '🙋‍♂️'}")
+```
+
+This would output something in the lines of
+
+```shell
+Aahnik Daw is a person 🙋‍♂️
+TestInti is a bot 😅
+```
+
+Do you see your name and the name of your integration?
+
+🎉 Congratulations, you are now ready to use notion-sdk-py!
+
+## Whats next ?
+
+With the simplicity of python and flexibility of Notion,
+you can connect Notion pages and databases to the tools you use every day,
+creating powerful workflows.
+
+notion-sdk-py has a lot of documentation.
+A high-level overview of how it’s organized will help you know where to look for
+certain things.
+
+- **[Examples](https://github.com/ramnes/notion-sdk-py/tree/main/examples)**
+Curated examples that are designed to make you learn.
+- **[Reference](reference/client.md)**
+Full reference of all public classes and methods.
+- **[Articles](https://www.google.com/search?q=articles+related+to+notion-sdk-py)**
+All articles discussing this library.
+- **[Videos](https://www.youtube.com/results?search_query=notion+sdk+py)**
+A list of videos that showcases related projects and tutorials.
+- **[Projects](https://github.com/ramnes/notion-sdk-py/network/dependents)**
+Compilation of open source projects that are using this library.
+- **[Discussions](https://github.com/ramnes/notion-sdk-py/discussions)**
+What people are discussing about notion-sdk-py.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+# Examples
+
+This section contains several single-file examples using [notion-sdk-py].
+
+Read the [Quick Start](/docs/quick_start.md) before you come here.
+
+## Downloading
+
+You may download all.
+
+```shell
+git clone https://github.com/ramnes/notion-sdk-py
+cd notion-sdk-py/examples
+ls # list all examples
+```
+
+All examples are licensed under the [CC0 License](https://creativecommons.org/choose/zero/),
+so you can use them as the base for your own code without worrying about copyright.

--- a/examples/first_project/README.md
+++ b/examples/first_project/README.md
@@ -1,0 +1,31 @@
+# First Project
+
+A simple project for beginners to get started with.
+
+## Objectives
+
+This project will show you how to:
+
+- Search for an item
+- Create a new page
+- Query a database
+
+## Create a demo page
+
+Lastly we need a notion page to experiment with.
+Duplicate [this page](https://www.notion.so/notion-sdk-py-540f8e2b79914654ba103c5d8a03e10e)
+in your workspace.
+Click on Share, and add your integration to this page.
+
+## Run the script
+
+Make sure your have `notion-sdk-py` installed.
+
+You may optionally install `python-dotenv`
+if you want the script to load your `.env` file.
+
+```shell
+python script.py
+```
+
+![notion_first_project](https://user-images.githubusercontent.com/66209958/119083985-a67e1c80-ba1e-11eb-9221-bea43f3c7b6e.gif)

--- a/examples/first_project/script.py
+++ b/examples/first_project/script.py
@@ -1,0 +1,74 @@
+import os
+import sys
+from pprint import pprint
+
+from notion_client import Client
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:
+    print("Could not load .env because python-dotenv not found.")
+else:
+    load_dotenv()
+
+NOTION_TOKEN = os.getenv("NOTION_TOKEN", "")
+
+while NOTION_TOKEN == "":
+    print("NOTION_TOKEN not found.")
+    NOTION_TOKEN = input("Enter your integration token: ").strip()
+
+# Initialize the client
+notion = Client(auth=NOTION_TOKEN)
+
+
+# Search for an item
+print("\nSearching for the word 'People' ")
+results = notion.search(query="People").get("results")
+print(len(results))
+result = results[0]
+print("The result is a", result["object"])
+pprint(result["properties"])
+
+database_id = result["id"]  # store the database id in a variable for future use
+
+# Create a new page
+your_name = input("\n\nEnter your name: ")
+gh_uname = input("Enter your github username: ")
+new_page = {
+    "Name": {"title": [{"text": {"content": your_name}}]},
+    "Tags": {"type": "multi_select", "multi_select": [{"name": "python"}]},
+    "GitHub": {
+        "type": "rich_text",
+        "rich_text": [
+            {
+                "type": "text",
+                "text": {"content": gh_uname},
+            },
+        ],
+    },
+}
+notion.pages.create(parent={"database_id": database_id}, properties=new_page)
+print("You were added to the People database!")
+
+
+# Query a database
+name = input("\n\nEnter the name of the person to search in People: ")
+results = notion.databases.query(
+    **{
+        "database_id": database_id,
+        "filter": {"property": "Name", "text": {"contains": name}},
+    }
+).get("results")
+
+no_of_results = len(results)
+
+if no_of_results == 0:
+    print("No results found.")
+    sys.exit()
+
+print(f"No of results found: {len(results)}")
+
+result = results[0]
+
+print(f"The first result is a {result['object']} with id {result['id']}.")
+print(f"This was created on {result['created_time']}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,55 @@
+site_name: notion-sdk-py
+
+repo_url: https://github.com/ramnes/notion-sdk-py
+
+edit_uri: ""
+
+theme:
+  name: material
+  navigation_depth: 4
+  features:
+    - navigation.tabs
+    - naviagation.sections
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Tahoma
+    code: Source Code Pro
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep orange
+      accent: orange
+      toggle:
+        icon: material/lightbulb-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: orange
+      accent: deep orange
+      toggle:
+        icon: material/lightbulb
+        name: Switch to light mode
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+        - docs/generate.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - section-index
+  - mkdocstrings
+  - coverage
+     
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.snippets:
+      check_paths: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ramnes/notion-sdk-py

--- a/notion_client/__init__.py
+++ b/notion_client/__init__.py
@@ -1,3 +1,11 @@
+"""Package notion-sdk-py.
+
+A sync + async python client for the official Notion API.
+Connect Notion pages and databases to the tools you use every day,
+creating powerful workflows.
+For more information visit https://github.com/ramnes/notion-sdk-py.
+"""
+
 from .client import AsyncClient, Client
 from .errors import APIErrorCode, APIResponseError
 

--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -1,3 +1,5 @@
+"""Notion API endpoints."""
+
 from typing import TYPE_CHECKING, Any
 
 from notion_client.helpers import pick
@@ -14,6 +16,10 @@ class Endpoint:
 
 class BlocksChildrenEndpoint(Endpoint):
     def append(self, block_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Create and append new children blocks to the block using the ID specified.
+
+        Returns the Block object which contains the new children.
+        """
         return self.parent.request(
             path=f"blocks/{block_id}/children",
             method="PATCH",
@@ -21,6 +27,12 @@ class BlocksChildrenEndpoint(Endpoint):
         )
 
     def list(self, block_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Return a paginated array of child block objects contained in the block.
+
+        In order to receive a complete representation of a block,
+        you may need to recursively retrieve the block children of child blocks.
+        The response may contain fewer than page_size of results.
+        """
         return self.parent.request(
             path=f"blocks/{block_id}/children",
             method="GET",
@@ -36,6 +48,10 @@ class BlocksEndpoint(Endpoint):
 
 class DatabasesEndpoint(Endpoint):
     def list(self, **kwargs: Any) -> SyncAsync[Any]:
+        """List all Databases shared with the authenticated integration.
+
+        The response may contain fewer than page_size of results.
+        """
         return self.parent.request(
             path="databases",
             method="GET",
@@ -43,6 +59,11 @@ class DatabasesEndpoint(Endpoint):
         )
 
     def query(self, database_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Get a list of Pages contained in the database.
+
+        The result is filtered and ordered according to the filter conditions
+        and sort criteria provided in the request.
+        """
         return self.parent.request(
             path=f"databases/{database_id}/query",
             method="POST",
@@ -51,6 +72,7 @@ class DatabasesEndpoint(Endpoint):
         )
 
     def retrieve(self, database_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Retrieve a Database object using the ID specified."""
         return self.parent.request(
             path=f"databases/{database_id}",
             method="GET",
@@ -59,6 +81,15 @@ class DatabasesEndpoint(Endpoint):
 
 class PagesEndpoint(Endpoint):
     def create(self, **kwargs: Any) -> SyncAsync[Any]:
+        """Create a new page in the specified database or as a child of an existing page.
+
+        If the parent is a database, the property values of the new page,
+        the properties parameter must conform to the parent database's property schema.
+
+        If the parent is a page, the only valid property is title.
+        The new page may include page content,
+        described as blocks in the children parameter.
+        """
         return self.parent.request(
             path="pages",
             method="POST",
@@ -66,12 +97,19 @@ class PagesEndpoint(Endpoint):
         )
 
     def retrieve(self, page_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Retrieve a Page object using the ID specified."""
         return self.parent.request(
             path=f"pages/{page_id}",
             method="GET",
         )
 
     def update(self, page_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Update page property values for the specified page.
+
+        Properties that are not set via the properties parameter will remain unchanged.
+        If the parent is a database, the new property values in the properties parameter
+        must conform to the parent database's property schema.
+        """
         return self.parent.request(
             path=f"pages/{page_id}", method="PATCH", body=pick(kwargs, "properties")
         )
@@ -79,6 +117,10 @@ class PagesEndpoint(Endpoint):
 
 class UsersEndpoint(Endpoint):
     def list(self, **kwargs: Any) -> SyncAsync[Any]:
+        """Return a paginated list of Users for the workspace.
+
+        The response may contain fewer than page_size of results.
+        """
         return self.parent.request(
             path="users",
             method="GET",
@@ -87,6 +129,7 @@ class UsersEndpoint(Endpoint):
         )
 
     def retrieve(self, user_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Retrieve a User using the ID specified."""
         return self.parent.request(
             path=f"users/{user_id}",
             method="GET",
@@ -95,6 +138,15 @@ class UsersEndpoint(Endpoint):
 
 class SearchEndpoint(Endpoint):
     def __call__(self, **kwargs: Any) -> SyncAsync[Any]:
+        """Search all pages and child pages that are shared with the integration.
+
+        The results may include databases.
+        The query parameter matches against the page titles.
+        If the query parameter is not provided,
+        the response will contain all pages (and child pages) in the results.
+        The filter parameter can be used to query specifically
+        for only pages or only databases.
+        """
         return self.parent.request(
             path="search",
             method="POST",

--- a/notion_client/client.py
+++ b/notion_client/client.py
@@ -1,3 +1,5 @@
+"""Sync and async clients for notion-sdk-py."""
+
 import logging
 from abc import abstractclassmethod
 from dataclasses import dataclass
@@ -27,6 +29,21 @@ from notion_client.typing import SyncAsync
 
 @dataclass
 class ClientOptions:
+    """Options to configure the client.
+
+    Attributes:
+        auth: Bearer token for authentication. If left undefined,
+        the `auth` parameter should be set on each request.
+        timeout_ms: Number of milliseconds to wait
+        before emitting a `RequestTimeoutError`
+        base_url: The root URL for sending API requests.
+        This can be changed to test with a mock server.
+        log_level: Verbosity of logs the instance will produce.
+        By default, logs are written to `stdout`.
+        logger: A custom logger.
+        notion_version: Version to Notion to use.
+    """
+
     auth: Optional[str] = None
     timeout_ms: int = 60_000
     base_url: str = "https://api.notion.com"
@@ -104,10 +121,13 @@ class BaseClient:
         body: Optional[Dict[Any, Any]] = None,
         auth: Optional[str] = None,
     ) -> SyncAsync[Any]:
+        # noqa
         pass
 
 
 class Client(BaseClient):
+    """Sync client for Notion API."""
+
     client: httpx.Client
 
     def __init__(
@@ -128,12 +148,15 @@ class Client(BaseClient):
         body: Optional[Dict[Any, Any]] = None,
         auth: Optional[str] = None,
     ) -> Any:
+        """Send an HTTP request."""
         request = self._build_request(method, path, query, body)
         response = self.client.send(request)
         return self._parse_response(response)
 
 
 class AsyncClient(BaseClient):
+    """Async client for Notion API."""
+
     client: httpx.AsyncClient
 
     def __init__(
@@ -154,6 +177,7 @@ class AsyncClient(BaseClient):
         body: Optional[Dict[Any, Any]] = None,
         auth: Optional[str] = None,
     ) -> Any:
+        """Send an HTTP request using async client."""
         request = self._build_request(method, path, query, body)
         async with self.client as client:
             response = await client.send(request)

--- a/notion_client/errors.py
+++ b/notion_client/errors.py
@@ -1,3 +1,9 @@
+"""Custom Exceptions for notion-sdk-py.
+
+This module defines python Exceptions that are raised when their
+corresponding HTTP response codes are returned by Notion API.
+"""
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
@@ -6,14 +12,24 @@ import httpx
 
 
 class RequestTimeoutError(Exception):
+    """Request timed out.
+
+    The request that we made waits for a specified period of time or maximum number
+    of retries to get the response.
+    But if no response comes within the limited time or retries,
+    then this Exception is raised.
+    """
+
     code = "notionhq_client_request_timeout"
 
     def __init__(self, message: str = "Request to Notion API has timed out") -> None:
+        """Initialize  RequestTimeoutError."""
         super().__init__(message)
         self.name = "RequestTimeoutError"
 
     @staticmethod
     def is_request_timeout_error(e: Exception) -> bool:
+        """Check if Exception is an request timeout error."""
         return (
             isinstance(e, RequestTimeoutError)
             and hasattr(e, "code")
@@ -22,6 +38,12 @@ class RequestTimeoutError(Exception):
 
 
 class HTTPResponseError(Exception):
+    """HTTP Response Errors.
+
+    Responses from the API use HTTP response codes that are used to
+    indicate general classes of success and error.
+    """
+
     code: str = "notionhq_client_response_error"
     status: int
     headers: httpx.Headers
@@ -37,6 +59,7 @@ class HTTPResponseError(Exception):
         self.body = response.text
 
     def is_http_response_error(e: Exception) -> bool:
+        """Check if Exception is an http response error."""
         return (
             isinstance(e, HTTPResponseError)
             and hasattr(e, "code")
@@ -45,17 +68,46 @@ class HTTPResponseError(Exception):
 
 
 class APIErrorCode(str, Enum):
+    """Enumerate API error codes."""
+
     Unauthorized = "unauthorized"
+    """The bearer token is not valid."""
+
     RestrictedResource = "restricted_resource"
+    """Given the bearer token used, the client doesn't have permission to
+    perform this operation."""
+
     ObjectNotFound = "object_not_found"
+    """Given the bearer token used, the resource does not exist.
+    This error can also indicate that the resource has not been shared with owner
+    of the bearer token."""
+
     RateLimited = "rate_limited"
+    """This request exceeds the number of requests allowed. Slow down and try again."""
+
     InvalidJSON = "invalid_json"
+    """The request body could not be decoded as JSON."""
+
     InvalidRequestURL = "invalid_request_url"
+    """The request URL is not valid."""
+
     InvalidRequest = "invalid_request"
+    """This request is not supported."""
+
     ValidationError = "validation_error"
+    """The request body does not match the schema for the expected parameters."""
+
     ConflictError = "conflict_error"
+    """The transaction could not be completed, potentially due to a data collision.
+    Make sure the parameters are up to date and try again."""
+
     InternalServerError = "internal_server_error"
+    """An unexpected error occurred. Reach out to Notion support."""
+
     ServiceUnavailable = "service_unavailable"
+    """Notion is unavailable. Try again later.
+    This can occur when the time to respond to a request takes longer than 60 seconds,
+    the maximum request timeout."""
 
 
 @dataclass
@@ -65,14 +117,18 @@ class APIErrorResponseBody:
 
 
 class APIResponseError(HTTPResponseError):
+    """An error raised by Notion API."""
+
     code: APIErrorCode
 
     def __init__(self, response: httpx.Response, body: APIErrorResponseBody) -> None:
+        """Initialize api response error."""
         super().__init__(response, body.message)
         self.code = body.code
 
     @staticmethod
     def is_api_response_error(e: Exception) -> bool:
+        """Check if Exception is an API response error."""
         return (
             isinstance(e, APIResponseError)
             and hasattr(e, "code")
@@ -84,11 +140,13 @@ class APIResponseError(HTTPResponseError):
 
 
 def is_api_error_code(code: str) -> bool:
+    """Check if given code belongs to the list of valid API error codes."""
     codes = [error_code.value for error_code in APIErrorCode]
     return type(code) == str and code in codes
 
 
 def is_timeout_error(e: Exception) -> bool:
+    """Check if Exception is a timeout error."""
     return (
         isinstance(e, httpx.TimeoutException)
         and hasattr(e, "request")
@@ -97,6 +155,7 @@ def is_timeout_error(e: Exception) -> bool:
 
 
 def is_http_error(e: Exception) -> bool:
+    """Check if Exception is an HTTP error."""
     return (
         isinstance(e, httpx.HTTPStatusError)
         and hasattr(e, "request")

--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -1,5 +1,8 @@
+"""Utility functions for notion-sdk-py."""
+
 from typing import Any, Dict
 
 
 def pick(base: Dict[Any, Any], *keys: str) -> Dict[Any, Any]:
+    """Return a Dict composed of key value pairs for keys passed as args."""
     return {key: base[key] for key in keys if key in base}

--- a/notion_client/logging.py
+++ b/notion_client/logging.py
@@ -1,8 +1,11 @@
+"""Custom logging for notion-sdk-py."""
+
 import logging
 from logging import Logger
 
 
 def make_console_logger() -> Logger:
+    """Return a custom logger."""
     logger = logging.getLogger(__package__)
     handler = logging.StreamHandler()
     formatter = logging.Formatter(logging.BASIC_FORMAT)

--- a/notion_client/typing.py
+++ b/notion_client/typing.py
@@ -1,3 +1,5 @@
+"""Custom type definitions for notion-sdk-py."""
+
 from typing import Awaitable, TypeVar, Union
 
 T = TypeVar("T")

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,7 @@
+mkdocs
+mkdocstrings
+mkdocs-coverage
+mkdocs-gen-files
+mkdocs-literate-nav
+mkdocs-material
+mkdocs-section-index

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal=1
 
 [tool:pytest]
 minversion = 6.0
-addopts = --cov=./notion_client --cov-report=term-missing --cov-report=xml
+addopts = --cov=./notion_client --cov-report=term-missing --cov-report=xml --cov-report=html
 
 [flake8]
 max-line-length = 89
@@ -25,3 +25,9 @@ warn_return_any = True
 implicit_reexport = False
 strict_equality = True
 # --strict end
+
+[pydocstyle]
+ignore = D101, D107, D203, D212, D213, D214, D215, D404, D405, D406, D407, D408, D409, D410, D411, D413, D415, D416, D417
+# D101	Missing docstring in public class
+# D107	Missing docstring in __init__
+# rest of the ignored errors are pep257 defaults


### PR DESCRIPTION
Live preview of gh pages site https://aahnik.github.io/notion-sdk-py/
Live preview how new things look like: https://github.com/aahnik/notion-sdk-py/tree/docs-patch-1

fixes #29 

- [x] mkdocs setup
- [x] auto-publish docs ci
- [x] add docstrings that can be seen on calling `help()` or hovering (in modern IDEs) 
- [x] [google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) markdown compatible docstrings (style enforced by [pydocstyle](https://github.com/PyCQA/pydocstyle))
- [x] add the reference section to the docs site
- [x] write the example usage
- [x] polish the docs
- [x] remove bloat
- [x] make changes requested by @ramnes 
- [x] clean commits