### PR TITLE
Add pytest-cov to testenv deps in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,7 @@
 envlist = py37,py38,py39
 
 [testenv]
-deps = pytest
+deps =
+	pytest
+	pytest-cov
 commands = pytest


### PR DESCRIPTION
We had configured the `setup.cfg` for pytest. Thus whenever pytest is run, it runs with the arguments defined in `setup.cfg`

https://github.com/ramnes/notion-sdk-py/blob/4527ffcd66ec2f7c0e26cb00718da04838488977/setup.cfg#L4-L6

But the `--cov` options are available only when `pytest-cov` is installed.

If you run `tox`, you will get:

```shell
py37 run-test: commands[0] | pytest
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov=./notion_client --cov-report=term-missing --cov-report=xml
  inifile: /home/aahnik/Desktop/notion-sdk-py/setup.cfg
  rootdir: /home/aahnik/Desktop/notion-sdk-py

ERROR: InvocationError for command /home/aahnik/Desktop/notion-sdk-py/.tox/py37/bin/pytest (exited with code 4)
```

To fix that, we need to include `pytest-cov` in the `deps` of the `testenv` for `tox.ini`.