### PR TITLE
Fix netloc checking of get_url in url helpers

### DIFF
--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -17,7 +17,7 @@ def get_url(object_id: str) -> str:
 def get_id(url: str) -> str:
     """Return the id of the object behind the given URL."""
     parsed = urlparse(url)
-    if parsed.netloc != "www.notion.so":
+    if parsed.netloc not in ("notion.so", "www.notion.so"):
         raise ValueError("Not a valid Notion URL.")
     path = parsed.path
     if len(path) < 32:

--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -17,7 +17,7 @@ def get_url(object_id: str) -> str:
 def get_id(url: str) -> str:
     """Return the id of the object behind the given URL."""
     parsed = urlparse(url)
-    if parsed.netloc != "notion.so":
+    if parsed.netloc != "www.notion.so":
         raise ValueError("Not a valid Notion URL.")
     path = parsed.path
     if len(path) < 32:


### PR DESCRIPTION
I changed `netloc`'s comparing string to `www.notion.so` instead of `notion.so`

When I ran `get_url` function in url helpers with my notion page, it said "Not a valid Notion URL".
I looked at the code and it was
```
if parsed.netloc != "notion.so":
    raise ValueError("Not a valid Notion URL.")
```

But as you see the screenshot below, the `netloc` is just `www.notion.so`, not `notion.so`

![Screen Shot 2021-09-28 at 6 29 21 PM](https://user-images.githubusercontent.com/50057022/135063723-4ea8b6da-bb74-4d37-9f1c-654ac31c80fe.png)

Thus, I changed it and it works now

