### PR TITLE
fix(Blocks-Delete): Add missing /

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -85,7 +85,7 @@ class BlocksEndpoint(Endpoint):
     def delete(self, block_id: str, **kwargs: Any) -> SyncAsync[Any]:
         """TBA."""
         return self.parent.request(
-            path=f"blocks{block_id}",
+            path=f"blocks/{block_id}",
             method="DELETE",
             auth=kwargs.get("auth"),
         )


### PR DESCRIPTION
Hello there 👋

The api endpoint DELETE blocks/block_id was missing the `/` which was making the request fail.

If you test to call `blocks.delete(block_id=f'/{your_block_id}')` (Adding the missing `/`) on the main branch it works.

So here is a simple fix.