### PR TITLE
Added api endpoints test cases (blocks, blocks_children)

### DIFF
--- a/tests/api_endpoints/cassettes/test_endpoint_blocks_children_append.yaml
+++ b/tests/api_endpoints/cassettes/test_endpoint_blocks_children_append.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: '{"children": [{"object": "block", "type": "heading_2", "heading_2": {"text":
+      [{"type": "text", "text": {"content": "Lacinato kale"}}]}}, {"object": "block",
+      "type": "paragraph", "paragraph": {"text": [{"type": "text", "text": {"content":
+      "Lacinato kale is a variety of kale with a long tradition in Italian cuisine,
+      especially that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur
+      kale, kale, flat back kale, palm tree kale, or black Tuscan palm.", "link":
+      {"url": "https://en.wikipedia.org/wiki/Lacinato_kale"}}}]}}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret_...
+      connection:
+      - keep-alive
+      content-length:
+      - '537'
+      content-type:
+      - application/json
+      host:
+      - api.notion.com
+      notion-version:
+      - '2021-08-16'
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/77897eca-aae1-4e6a-906f-e01e5a3c2385/children
+  response:
+    content: '{"object":"list","results":[{"object":"block","id":"b2d2ca05-1e48-43e0-90d6-61c9bc45fd53","created_time":"2022-02-26T04:00:00.000Z","last_edited_time":"2022-02-26T04:00:00.000Z","created_by":{"object":"user","id":"b804c1af-b5ba-45b3-977b-e9f2f05b437d"},"last_edited_by":{"object":"user","id":"b804c1af-b5ba-45b3-977b-e9f2f05b437d"},"has_children":false,"archived":false,"type":"heading_2","heading_2":{"text":[{"type":"text","text":{"content":"Lacinato
+      kale","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lacinato
+      kale","href":null}]}},{"object":"block","id":"7a08bfd1-4626-4fcf-8308-f604c5ac6d81","created_time":"2022-02-26T04:00:00.000Z","last_edited_time":"2022-02-26T04:00:00.000Z","created_by":{"object":"user","id":"b804c1af-b5ba-45b3-977b-e9f2f05b437d"},"last_edited_by":{"object":"user","id":"b804c1af-b5ba-45b3-977b-e9f2f05b437d"},"has_children":false,"archived":false,"type":"paragraph","paragraph":{"text":[{"type":"text","text":{"content":"Lacinato
+      kale is a variety of kale with a long tradition in Italian cuisine, especially
+      that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale,
+      kale, flat back kale, palm tree kale, or black Tuscan palm.","link":{"url":"https://en.wikipedia.org/wiki/Lacinato_kale"}},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lacinato
+      kale is a variety of kale with a long tradition in Italian cuisine, especially
+      that of Tuscany. It is also known as Tuscan kale, Italian kale, dinosaur kale,
+      kale, flat back kale, palm tree kale, or black Tuscan palm.","href":"https://en.wikipedia.org/wiki/Lacinato_kale"}]}}],"next_cursor":null,"has_more":false}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/api_endpoints/cassettes/test_endpoint_blocks_children_list.yaml
+++ b/tests/api_endpoints/cassettes/test_endpoint_blocks_children_list.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2021-08-16'
+    method: GET
+    uri: https://api.notion.com/v1/blocks/69bf5c26-ff31-4d18-a331-c6d1746dec26/children
+  response:
+    content: '{"object":"list","results":[{"object":"block","id":"ab8405b1-a7f7-42ef-a673-75f319838351","created_time":"2022-02-26T04:14:00.000Z","last_edited_time":"2022-02-26T04:14:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"text":[{"type":"text","text":{"content":"1st
+      element","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"1st
+      element","href":null}]}},{"object":"block","id":"db1a418f-493b-40f9-85a1-5261d2ed2b83","created_time":"2022-02-26T04:14:00.000Z","last_edited_time":"2022-02-26T04:14:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"text":[{"type":"text","text":{"content":"2nd
+      element","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"2nd
+      element","href":null}]}},{"object":"block","id":"1d900457-9ca2-4c19-835d-b9f46d9074eb","created_time":"2022-02-26T04:14:00.000Z","last_edited_time":"2022-02-26T04:14:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"text":[{"type":"text","text":{"content":"3rd
+      element","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"3rd
+      element","href":null}]}},{"object":"block","id":"7c6ba21d-c33a-452e-8a19-573941bca4a3","created_time":"2022-02-26T04:14:00.000Z","last_edited_time":"2022-02-26T04:14:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"text":[{"type":"text","text":{"content":"4th
+      element","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"4th
+      element","href":null}]}},{"object":"block","id":"ff538d97-4144-45b5-92f0-faa5896eb2d0","created_time":"2022-02-26T04:14:00.000Z","last_edited_time":"2022-02-26T04:14:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"text":[{"type":"text","text":{"content":"5th
+      element","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"5th
+      element","href":null}]}}],"next_cursor":null,"has_more":false}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2021-08-16'
+    method: GET
+    uri: https://api.notion.com/v1/blocks/69bf5c26-ff31-4d18-a331-c6d1746dec26/children?page_size=2
+  response:
+    content: '{"object":"list","results":[{"object":"block","id":"ab8405b1-a7f7-42ef-a673-75f319838351","created_time":"2022-02-26T04:14:00.000Z","last_edited_time":"2022-02-26T04:14:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"text":[{"type":"text","text":{"content":"1st
+      element","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"1st
+      element","href":null}]}},{"object":"block","id":"db1a418f-493b-40f9-85a1-5261d2ed2b83","created_time":"2022-02-26T04:14:00.000Z","last_edited_time":"2022-02-26T04:14:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"bulleted_list_item","bulleted_list_item":{"text":[{"type":"text","text":{"content":"2nd
+      element","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"2nd
+      element","href":null}]}}],"next_cursor":"1d900457-9ca2-4c19-835d-b9f46d9074eb","has_more":true}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/api_endpoints/cassettes/test_endpoint_blocks_delete.yaml
+++ b/tests/api_endpoints/cassettes/test_endpoint_blocks_delete.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2021-08-16'
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/3940db22-35c6-4b39-9db4-615f7485aa34
+  response:
+    content: '{"object":"block","id":"3940db22-35c6-4b39-9db4-615f7485aa34","created_time":"2022-02-26T03:48:00.000Z","last_edited_time":"2022-02-26T03:51:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"b804c1af-b5ba-45b3-977b-e9f2f05b437d"},"has_children":false,"archived":true,"type":"paragraph","paragraph":{"text":[{"type":"text","text":{"content":"TEST_BLOCK_DELETE","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"TEST_BLOCK_DELETE","href":null}]}}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/api_endpoints/cassettes/test_endpoint_blocks_retrieve.yaml
+++ b/tests/api_endpoints/cassettes/test_endpoint_blocks_retrieve.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2021-08-16'
+    method: GET
+    uri: https://api.notion.com/v1/blocks/b8624a96-0a9e-4b14-8ef8-464aae13f9b9
+  response:
+    content: '{"object":"block","id":"b8624a96-0a9e-4b14-8ef8-464aae13f9b9","created_time":"2022-02-25T16:22:00.000Z","last_edited_time":"2022-02-25T16:38:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"has_children":false,"archived":false,"type":"paragraph","paragraph":{"text":[{"type":"text","text":{"content":"TEST_BLOCK","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"TEST_BLOCK","href":null}]}}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/api_endpoints/cassettes/test_endpoint_blocks_update.yaml
+++ b/tests/api_endpoints/cassettes/test_endpoint_blocks_update.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: '{"to_do": {"text": [{"type": "text", "text": {"content": "Lacinato kale"}}],
+      "checked": false}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret_...
+      connection:
+      - keep-alive
+      content-length:
+      - '95'
+      content-type:
+      - application/json
+      host:
+      - api.notion.com
+      notion-version:
+      - '2021-08-16'
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/0f06f246-1250-4da8-9100-f8fe0a537433
+  response:
+    content: '{"object":"block","id":"0f06f246-1250-4da8-9100-f8fe0a537433","created_time":"2022-02-25T17:36:00.000Z","last_edited_time":"2022-02-25T17:36:00.000Z","created_by":{"object":"user","id":"490a7c39-6a77-467d-a04f-8a1a0983fdfc"},"last_edited_by":{"object":"user","id":"b804c1af-b5ba-45b3-977b-e9f2f05b437d"},"has_children":false,"archived":false,"type":"to_do","to_do":{"checked":false,"text":[{"type":"text","text":{"content":"Lacinato
+      kale","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lacinato
+      kale","href":null}]}}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/api_endpoints/test_blocks.py
+++ b/tests/api_endpoints/test_blocks.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from notion_client.client import Client
+
+
+@pytest.mark.vcr()
+def test_endpoint_blocks_retrieve(client: "Client"):
+    block_id = "b8624a96-0a9e-4b14-8ef8-464aae13f9b9"
+
+    response: Any = client.blocks.retrieve(block_id=block_id)
+    assert response["id"] == block_id
+    assert response["object"] == "block"

--- a/tests/api_endpoints/test_blocks.py
+++ b/tests/api_endpoints/test_blocks.py
@@ -13,3 +13,20 @@ def test_endpoint_blocks_retrieve(client: "Client"):
     response: Any = client.blocks.retrieve(block_id=block_id)
     assert response["id"] == block_id
     assert response["object"] == "block"
+
+
+@pytest.mark.vcr()
+def test_endpoint_blocks_update(client: "Client"):
+    block_id = "0f06f246-1250-4da8-9100-f8fe0a537433"
+
+    response: Any = client.blocks.update(
+        block_id=block_id,
+        to_do={
+            "text": [{"type": "text", "text": {"content": "Lacinato kale"}}],
+            "checked": False,
+        },
+    )
+
+    assert response["id"] == block_id
+    assert response["type"] == "to_do"
+    assert not response["to_do"]["checked"]

--- a/tests/api_endpoints/test_blocks.py
+++ b/tests/api_endpoints/test_blocks.py
@@ -11,6 +11,7 @@ def test_endpoint_blocks_retrieve(client: "Client"):
     block_id = "b8624a96-0a9e-4b14-8ef8-464aae13f9b9"
 
     response: Any = client.blocks.retrieve(block_id=block_id)
+
     assert response["id"] == block_id
     assert response["object"] == "block"
 
@@ -30,3 +31,16 @@ def test_endpoint_blocks_update(client: "Client"):
     assert response["id"] == block_id
     assert response["type"] == "to_do"
     assert not response["to_do"]["checked"]
+
+
+@pytest.mark.vcr()
+def test_endpoint_blocks_delete(client: "Client"):
+    block_id = "3940db22-35c6-4b39-9db4-615f7485aa34"
+
+    response: Any = client.blocks.delete(
+        block_id=block_id,
+    )
+
+    assert response["id"] == block_id
+    assert response["object"] == "block"
+    assert response["archived"]

--- a/tests/api_endpoints/test_blocks_children.py
+++ b/tests/api_endpoints/test_blocks_children.py
@@ -1,0 +1,87 @@
+from typing import TYPE_CHECKING, Any, Optional
+
+import pytest
+
+if TYPE_CHECKING:
+    from notion_client.client import Client
+
+
+@pytest.mark.vcr()
+def test_endpoint_blocks_children_append(client: "Client"):
+    block_id = "77897eca-aae1-4e6a-906f-e01e5a3c2385"
+
+    response: Any = client.blocks.children.append(
+        block_id=block_id,
+        children=[
+            {
+                "object": "block",
+                "type": "heading_2",
+                "heading_2": {
+                    "text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": "Lacinato kale",
+                            },
+                        },
+                    ],
+                },
+            },
+            {
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "text": [
+                        {
+                            "type": "text",
+                            "text": {
+                                "content": (
+                                    "Lacinato kale is a variety of kale with a long "
+                                    "tradition in Italian cuisine, especially that of "
+                                    "Tuscany. It is also known as Tuscan kale, Italian "
+                                    "kale, dinosaur kale, kale, flat back kale, palm "
+                                    "tree kale, or black Tuscan palm."
+                                ),
+                                "link": {
+                                    "url": "https://en.wikipedia.org/wiki/Lacinato_kale",
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    )
+
+    assert response["object"] == "list"
+
+    # Check children blocks exists
+    heading_2_block: Optional[dict] = None
+    paragraph_block: Optional[dict] = None
+
+    for result in response["results"]:
+        if result["type"] == "heading_2" and "heading_2" in result:
+            heading_2_block = result
+
+        if result["type"] == "paragraph" and "paragraph" in result:
+            paragraph_block = result
+
+    assert heading_2_block is not None
+    assert paragraph_block is not None
+
+
+@pytest.mark.vcr()
+def test_endpoint_blocks_children_list(client: "Client"):
+    block_id = "69bf5c26-ff31-4d18-a331-c6d1746dec26"
+
+    # Without kwargs
+    response: Any = client.blocks.children.list(block_id=block_id)
+
+    assert response["object"] == "list"
+    assert response["results"]
+
+    # With kwargs (page_size)
+    response: Any = client.blocks.children.list(block_id=block_id, page_size=2)
+
+    assert response["object"] == "list"
+    assert len(response["results"]) == 2


### PR DESCRIPTION
I made a subdirectory `./tests/api_endpoints/` for `./notion_client/api_endpoints.py` test cases, since there are amount of classes.

Any comments are welcome.

- Added `BlocksEndpoint`, `BlocksChildrenEndpoint` test case
- Some request/response come from [notion api document](https://developers.notion.com/reference/intro).
