### PR TITLE
Fixed incorrect params in the Comments endpoint

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -278,7 +278,7 @@ class CommentsEndpoint(Endpoint):
         return self.parent.request(
             path="comments",
             method="POST",
-            query=pick(kwargs, "parent", "discussion_id", "rich_text"),
+            body=pick(kwargs, "parent", "discussion_id", "rich_text"),
             auth=kwargs.get("auth"),
         )
 


### PR DESCRIPTION
While working on the tests I noticed that the params in the client.comment.create endpoint was incorrect. I swapped query with body