### PR TITLE
Explicitly use `notion_client` as package to avoid exporting `tests`

### DIFF
--- a/notion_client/client.py
+++ b/notion_client/client.py
@@ -89,7 +89,7 @@ class BaseClient:
         client.headers = httpx.Headers(
             {
                 "Notion-Version": self.options.notion_version,
-                "User-Agent": "ramnes/notion-sdk-py@1.0.0",
+                "User-Agent": "ramnes/notion-sdk-py@1.0.1",
             }
         )
         if self.options.auth:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 def get_description():
@@ -8,14 +8,14 @@ def get_description():
 
 setup(
     name="notion-client",
-    version="1.0.0",
+    version="1.0.1",
     url="https://github.com/ramnes/notion-sdk-py",
     author="Guillaume Gelin",
     author_email="contact@ramnes.eu",
     description="Python client for the official Notion API",
     long_description=get_description(),
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=["notion_client"],
     python_requires=">=3.7, <4",
     install_requires=[
         "httpx >= 0.15.0",


### PR DESCRIPTION
Using `find_packages` in setup.py also exports `tests`, as that has a `__init__.py`. 

```
>>> from setuptools import find_packages
>>> find_packages()
['tests', 'notion_client']
```

This causes issues when `notion-client` is used in projects with pylint that contain a `tests` directory, as pylint prefers the installed `tests` package from notion-client over the local discovered `tests` directory.

An alternative approach would be to remove the `__init__.py`, but I'm not sure if it's there for a specific reason. 

LMK if you need any more info - I've run through the pre-commit hooks and it all looks good.

Thanks for the great project - does the job well.