### PR TITLE
add support for inline database property write

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -165,7 +165,7 @@ class DatabasesEndpoint(Endpoint):
         return self.parent.request(
             path=f"databases/{database_id}",
             method="PATCH",
-            body=pick(kwargs, "properties", "title", "icon", "cover"),
+            body=pick(kwargs, "properties", "title", "icon", "cover", "is_inline"),
             auth=kwargs.get("auth"),
         )
 


### PR DESCRIPTION
[This API changelog](https://developers.notion.com/changelog/changes-for-june-6-june-20-2022) adds support for creating/updating databases with `is_inline`. Implementation into this SDK is trivial -- simply adding `"is_inline"` to the `pick` args for database `create` and `update` did the trick.