### PR TITLE
Allow passing starting cursor in paginated helper

### DIFF
--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -27,9 +27,11 @@ def get_id(url: str) -> str:
 
 
 def iterate_paginated_api(
-    function: Callable[..., Any], next_cursor = None, **kwargs: Any
+    function: Callable[..., Any], **kwargs: Any
 ) -> Generator[List[Any], None, None]:
     """Return an iterator over the results of any paginated Notion API."""
+    next_cursor = kwargs.pop("start_cursor", None)
+
     while True:
         response = function(**kwargs, start_cursor=next_cursor)
         yield response.get("results")
@@ -48,9 +50,11 @@ def collect_paginated_api(function: Callable[..., Any], **kwargs: Any) -> List[A
 
 
 async def async_iterate_paginated_api(
-    function: Callable[..., Awaitable[Any]], next_cursor = None, **kwargs: Any
+    function: Callable[..., Awaitable[Any]], **kwargs: Any
 ) -> AsyncGenerator[List[Any], None]:
     """Return an async iterator over the results of any paginated Notion API."""
+    next_cursor = kwargs.pop("start_cursor", None)
+
     while True:
         response = await function(**kwargs, start_cursor=next_cursor)
         yield response.get("results")

--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -27,11 +27,9 @@ def get_id(url: str) -> str:
 
 
 def iterate_paginated_api(
-    function: Callable[..., Any], **kwargs: Any
+    function: Callable[..., Any], next_cursor = None, **kwargs: Any
 ) -> Generator[List[Any], None, None]:
     """Return an iterator over the results of any paginated Notion API."""
-    next_cursor = None
-
     while True:
         response = function(**kwargs, start_cursor=next_cursor)
         yield response.get("results")
@@ -50,11 +48,9 @@ def collect_paginated_api(function: Callable[..., Any], **kwargs: Any) -> List[A
 
 
 async def async_iterate_paginated_api(
-    function: Callable[..., Awaitable[Any]], **kwargs: Any
+    function: Callable[..., Awaitable[Any]], next_cursor = None, **kwargs: Any
 ) -> AsyncGenerator[List[Any], None]:
     """Return an async iterator over the results of any paginated Notion API."""
-    next_cursor = None
-
     while True:
         response = await function(**kwargs, start_cursor=next_cursor)
         yield response.get("results")


### PR DESCRIPTION
Allow passing next_cursor to the paginated api to set the starting cursor.