### PR TITLE
Add missing endpoint arguments

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -67,6 +67,7 @@ class BlocksEndpoint(Endpoint):
                 "embed",
                 "type",
                 "archived",
+                "in_trash",
                 "bookmark",
                 "image",
                 "video",
@@ -133,7 +134,15 @@ class DatabasesEndpoint(Endpoint):
             path=f"databases/{database_id}/query",
             method="POST",
             query=pick(kwargs, "filter_properties"),
-            body=pick(kwargs, "filter", "sorts", "start_cursor", "page_size"),
+            body=pick(
+                kwargs,
+                "filter",
+                "sorts",
+                "start_cursor",
+                "page_size",
+                "archived",
+                "in_trash",
+            ),
             auth=kwargs.get("auth"),
         )
 
@@ -155,7 +164,14 @@ class DatabasesEndpoint(Endpoint):
             path="databases",
             method="POST",
             body=pick(
-                kwargs, "parent", "title", "properties", "icon", "cover", "is_inline"
+                kwargs,
+                "parent",
+                "title",
+                "description",
+                "properties",
+                "icon",
+                "cover",
+                "is_inline",
             ),
             auth=kwargs.get("auth"),
         )
@@ -176,6 +192,8 @@ class DatabasesEndpoint(Endpoint):
                 "icon",
                 "cover",
                 "is_inline",
+                "archived",
+                "in_trash",
             ),
             auth=kwargs.get("auth"),
         )


### PR DESCRIPTION
This Pull Request fixes an issue to align the implementation with the [official repository](https://github.com/makenotion/notion-sdk-js/tree/main).
Currently, the `pick()` method used to extract values for the API request body is missing some keys, causing a discrepancy with the official implementation.

This PR adds the missing keys to the `pick()` method’s arguments based on the official implementation, ensuring that the correct parameters are sent in the API request.

Please review the changes. Thank you!
