### PR TITLE
Adding OAuth revoke and introspect endpoints

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -325,3 +325,29 @@ class CommentsEndpoint(Endpoint):
             query=pick(kwargs, "block_id", "start_cursor", "page_size"),
             auth=kwargs.get("auth"),
         )
+
+
+class OAuthEndpoint(Endpoint):
+    def introspect(self, **kwargs: Any) -> SyncAsync[Any]:
+        """Introspect the provided token.
+
+        *[🔗 Endpoint documentation](https://developers.notion.com/reference/introspect-token)*
+        """
+        return self.parent.request(
+            path="oauth/introspect",
+            method="POST",
+            body=pick(kwargs, "token"),
+            auth=kwargs.get("auth"),
+        )
+
+    def revoke(self, **kwargs: Any) -> SyncAsync[Any]:
+        """Revoke the provided token.
+
+        *[🔗 Endpoint documentation](https://developers.notion.com/reference/revoke-token)*
+        """
+        return self.parent.request(
+            path="oauth/revoke",
+            method="POST",
+            body=pick(kwargs, "token"),
+            auth=kwargs.get("auth"),
+        )

--- a/notion_client/client.py
+++ b/notion_client/client.py
@@ -16,6 +16,7 @@ from notion_client.api_endpoints import (
     PagesEndpoint,
     SearchEndpoint,
     UsersEndpoint,
+    OAuthEndpoint,
 )
 from notion_client.errors import (
     APIResponseError,
@@ -77,6 +78,7 @@ class BaseClient:
         self.pages = PagesEndpoint(self)
         self.search = SearchEndpoint(self)
         self.comments = CommentsEndpoint(self)
+        self.oauth = OAuthEndpoint(self)
 
     @property
     def client(self) -> Union[httpx.Client, httpx.AsyncClient]:

--- a/tests/cassettes/test_introspect_token.yaml
+++ b/tests/cassettes/test_introspect_token.yaml
@@ -1,0 +1,29 @@
+interactions:
+- request:
+    body: '{"token": "ntn_..."}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Basic '"$BASE64_ENCODED_ID_AND_SECRET"'
+      connection:
+      - keep-alive
+      content-length:
+      - '63'
+      content-type:
+      - application/json
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+    method: POST
+    uri: https://api.notion.com/v1/oauth/introspect
+  response:
+    content: '{"active":true,"scope":"read_content insert_content update_content read_user_with_email
+      read_user_without_email","iat":1742002165921,"request_id":"14314d51-f34c-47a0-886b-4d792d9dad0c"}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_revoke_token.yaml
+++ b/tests/cassettes/test_revoke_token.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: '{"token": "ntn..."}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - Basic '"$BASE64_ENCODED_ID_AND_SECRET"'
+      connection:
+      - keep-alive
+      content-length:
+      - '63'
+      content-type:
+      - application/json
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+    method: POST
+    uri: https://api.notion.com/v1/oauth/revoke
+  response:
+    content: '{"request_id":"ba61313e-c752-49bc-858d-0d961eda422e"}'
+    headers: {}
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -199,3 +199,15 @@ def test_pages_delete(client, page_id):
     assert response
 
     client.pages.update(page_id=page_id, archived=False)
+
+
+@pytest.mark.vcr()
+def test_revoke_token(client, token):
+    response = client.oauth.revoke(token=token)
+    assert response
+
+
+@pytest.mark.vcr()
+def test_introspect_token(client, token):
+    response = client.oauth.introspect(token=token)
+    assert response


### PR DESCRIPTION
As described in Issue #260, 

> OAuth revoke and introspect endpoints got added to the JS SDK: https://github.com/makenotion/notion-sdk-js/pull/552

This PR adds that functionality to this SDK. 