### PR TITLE
Add missing VCR cassettes for `additional_data` and `request_id` tests

### DIFF
--- a/tests/cassettes/test_api_response_error_additional_data.yaml
+++ b/tests/cassettes/test_api_response_error_additional_data.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - ntn_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: GET
+    uri: https://api.notion.com/v1/users
+  response:
+    body:
+      string: '{"object":"error","status":401,"code":"unauthorized","message":"API
+        token is invalid.","request_id":"7ee2afd6-079d-4203-af08-d622988d8e19"}'
+    headers:
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/tests/cassettes/test_api_response_error_request_id.yaml
+++ b/tests/cassettes/test_api_response_error_request_id.yaml
@@ -1,0 +1,29 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: GET
+    uri: https://api.notion.com/v1/invalid
+  response:
+    body:
+      string: '{"object":"error","status":400,"code":"invalid_request_url","message":"Invalid
+        request URL.","request_id":"47e73e34-9e4c-4c38-ab4a-a46b5ad39b75"}'
+    headers:
+      Content-Length:
+      - '145'
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/tests/cassettes/test_async_api_response_error_additional_data.yaml
+++ b/tests/cassettes/test_async_api_response_error_additional_data.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - ntn_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: GET
+    uri: https://api.notion.com/v1/users
+  response:
+    body:
+      string: '{"object":"error","status":401,"code":"unauthorized","message":"API
+        token is invalid.","request_id":"8ee1aad8-c786-4eeb-972e-8c21c0b09dde"}'
+    headers:
+      Content-Length:
+      - '139'
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/tests/cassettes/test_async_api_response_error_request_id.yaml
+++ b/tests/cassettes/test_async_api_response_error_request_id.yaml
@@ -1,0 +1,29 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: GET
+    uri: https://api.notion.com/v1/invalid
+  response:
+    body:
+      string: '{"object":"error","status":400,"code":"invalid_request_url","message":"Invalid
+        request URL.","request_id":"ccf6e5b3-b771-4e67-a7c8-d80e8b9ab4cd"}'
+    headers:
+      Content-Length:
+      - '145'
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 400
+      message: Bad Request
+version: 1


### PR DESCRIPTION
This PR adds the missing VCR cassette files that were unintentionally left out in the previous PR.https://github.com/ramnes/notion-sdk-py/pull/293
No code changes, and only the cassette files are added.

Sorry for the oversight!
I actually added the new cassette files in my previous PR, but I accidentally forgot to include them in the commit.
Since the `tests\test_errors.py` coverage report showed 100%, I overlooked it at the time.
This PR adds those missing cassette files to make up for that.