### PR TITLE
Fix mypy compatibility with Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: markdownlint
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.900
+  rev: v1.18.2
   hooks:
   - id: mypy
     additional_dependencies: ["httpx"]


### PR DESCRIPTION
#298 

Update mypy from v0.900 (2021) to v1.18.2 (2025) to fix CI failures on Python 3.14.

The old version fails with 'The typed_ast package is not installed' error because typed_ast is incompatible with Python 3.14. GitHub Actions recently started defaulting to Python 3.14 for the check workflow, causing intermittent CI failures.

Tested with Docker python:3.14 image to confirm the fix works.