### PR TITLE
feat: add move method to pages endpoint

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -318,8 +318,8 @@ class PagesEndpoint(Endpoint):
         *[🔗 Endpoint documentation](https://developers.notion.com/reference/move-page)*
         """  # noqa: E501
         return self.parent.request(
-            path=f"pages/{page_id}",
-            method="PATCH",
+            path=f"pages/{page_id}/move",
+            method="POST",
             body=pick(kwargs, "parent"),
             auth=kwargs.get("auth"),
         )

--- a/tests/cassettes/test_move_pages.yaml
+++ b/tests/cassettes/test_move_pages.yaml
@@ -1,0 +1,228 @@
+interactions:
+- request:
+    body: '{"parent":{"page_id":"2ccb0add466d8068bab7d1ea9758677e"},"properties":{"title":[{"text":{"content":"Test
+      2025-12-17 19:15:07.513360"}}]},"children":[]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '151'
+      Content-Type:
+      - application/json
+      Host:
+      - api.notion.com
+      Notion-Version:
+      - '2025-09-03'
+      authorization:
+      - ntn_...
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    body:
+      string: '{"object":"page","id":"2cdb0add-466d-811d-80ea-cf0aee160c45","created_time":"2025-12-18T00:15:00.000Z","last_edited_time":"2025-12-18T00:15:00.000Z","created_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"last_edited_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"2ccb0add-466d-8068-bab7-d1ea9758677e"},"archived":false,"in_trash":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Test
+        2025-12-17 19:15:07.513360","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Test
+        2025-12-17 19:15:07.513360","href":null}]}},"url":"https://www.notion.so/Test-2025-12-17-19-15-07-513360-2cdb0add466d811d80eacf0aee160c45","public_url":null,"request_id":"b249fc0e-89d7-4e7d-a002-ae64730dca40"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '940'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parent":{"page_id":"2cdb0add-466d-811d-80ea-cf0aee160c45"},"properties":{"title":[{"text":{"content":"Target
+      Parent"}}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+      Host:
+      - api.notion.com
+      Notion-Version:
+      - '2025-09-03'
+      authorization:
+      - ntn_...
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    body:
+      string: '{"object":"page","id":"2cdb0add-466d-81a7-b352-d50688ff394a","created_time":"2025-12-18T00:15:00.000Z","last_edited_time":"2025-12-18T00:15:00.000Z","created_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"last_edited_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"2cdb0add-466d-811d-80ea-cf0aee160c45"},"archived":false,"in_trash":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Target
+        Parent","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
+        Parent","href":null}]}},"url":"https://www.notion.so/Target-Parent-2cdb0add466d81a7b352d50688ff394a","public_url":null,"request_id":"b16755c4-1d80-47fc-95be-79eddbc0e1ae"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '886'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parent":{"page_id":"2cdb0add-466d-811d-80ea-cf0aee160c45"},"properties":{"title":[{"text":{"content":"Moving
+      Page"}}]}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json
+      Host:
+      - api.notion.com
+      Notion-Version:
+      - '2025-09-03'
+      authorization:
+      - ntn_...
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    body:
+      string: '{"object":"page","id":"2cdb0add-466d-81fe-a920-e27de8c0bd70","created_time":"2025-12-18T00:15:00.000Z","last_edited_time":"2025-12-18T00:15:00.000Z","created_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"last_edited_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"2cdb0add-466d-811d-80ea-cf0aee160c45"},"archived":false,"in_trash":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Moving
+        Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Moving
+        Page","href":null}]}},"url":"https://www.notion.so/Moving-Page-2cdb0add466d81fea920e27de8c0bd70","public_url":null,"request_id":"fbaf6671-862c-4d5f-a3fd-aee211e73337"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '880'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parent":{"page_id":"2cdb0add-466d-81a7-b352-d50688ff394a"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-Type:
+      - application/json
+      Host:
+      - api.notion.com
+      Notion-Version:
+      - '2025-09-03'
+      authorization:
+      - ntn_...
+    method: POST
+    uri: https://api.notion.com/v1/pages/2cdb0add-466d-81fe-a920-e27de8c0bd70/move
+  response:
+    body:
+      string: '{"object":"page","id":"2cdb0add-466d-81fe-a920-e27de8c0bd70","created_time":"2025-12-18T00:15:00.000Z","last_edited_time":"2025-12-18T00:15:00.000Z","created_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"last_edited_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"2cdb0add-466d-81a7-b352-d50688ff394a"},"archived":false,"in_trash":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Moving
+        Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Moving
+        Page","href":null}]}},"url":"https://www.notion.so/Moving-Page-2cdb0add466d81fea920e27de8c0bd70","public_url":null,"request_id":"3b4bf768-0de9-4dc1-8b41-c503857f4b17"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '880'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.notion.com
+      Notion-Version:
+      - '2025-09-03'
+      authorization:
+      - ntn_...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/2cdb0add-466d-81fe-a920-e27de8c0bd70
+  response:
+    body:
+      string: '{"object":"block","id":"2cdb0add-466d-81fe-a920-e27de8c0bd70","parent":{"type":"page_id","page_id":"2cdb0add-466d-81a7-b352-d50688ff394a"},"created_time":"2025-12-18T00:15:00.000Z","last_edited_time":"2025-12-18T00:15:00.000Z","created_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"last_edited_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"has_children":false,"archived":true,"in_trash":true,"type":"child_page","child_page":{"title":"Moving
+        Page"},"request_id":"21b059b3-d2de-452e-ad1c-e2d9c0edc15d"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '543'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.notion.com
+      Notion-Version:
+      - '2025-09-03'
+      authorization:
+      - ntn_...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/2cdb0add-466d-81a7-b352-d50688ff394a
+  response:
+    body:
+      string: '{"object":"block","id":"2cdb0add-466d-81a7-b352-d50688ff394a","parent":{"type":"page_id","page_id":"2cdb0add-466d-811d-80ea-cf0aee160c45"},"created_time":"2025-12-18T00:15:00.000Z","last_edited_time":"2025-12-18T00:15:00.000Z","created_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"last_edited_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"has_children":false,"archived":true,"in_trash":true,"type":"child_page","child_page":{"title":"Target
+        Parent"},"request_id":"3b27bd46-9a42-433d-9fd7-16624161f75a"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '545'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Host:
+      - api.notion.com
+      Notion-Version:
+      - '2025-09-03'
+      authorization:
+      - ntn_...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/2cdb0add-466d-811d-80ea-cf0aee160c45
+  response:
+    body:
+      string: '{"object":"block","id":"2cdb0add-466d-811d-80ea-cf0aee160c45","parent":{"type":"page_id","page_id":"2ccb0add-466d-8068-bab7-d1ea9758677e"},"created_time":"2025-12-18T00:15:00.000Z","last_edited_time":"2025-12-18T00:15:00.000Z","created_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"last_edited_by":{"object":"user","id":"19683ed5-ee16-48af-b766-9c9eb6d58ebb"},"has_children":false,"archived":true,"in_trash":true,"type":"child_page","child_page":{"title":"Test
+        2025-12-17 19:15:07.513360"},"request_id":"40ccfc78-ef75-4230-a86d-72a24a6e63e8"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '563'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -562,52 +562,15 @@ def test_oauth_token_refresh_token(client, mocker):
     assert call_kwargs["path"] == "oauth/token"
 
 
-def test_move_pages(client, mocker):
-    """Test moving a page to a new parent (mocked)."""
-
-    mock_target_parent = {
-        "object": "page",
-        "id": "target-parent-id-456",
-        "parent": {"page_id": "root-page-123"},
-    }
-
-    mock_page_to_move = {
-        "object": "page",
-        "id": "page-to-move-id-789",
-        "parent": {"page_id": "root-page-123"},
-    }
-
-    mock_move_response = {
-        "object": "page",
-        "id": "page-to-move-id-789",
-        "parent": {"page_id": "target-parent-id-456"},
-    }
-
-    mock_delete_response = {
-        "object": "block",
-        "id": "page-to-move-id-789",
-        "archived": True,
-    }
-
-    mock_request = mocker.patch.object(
-        client,
-        "request",
-        side_effect=[
-            mock_target_parent,
-            mock_page_to_move,
-            mock_move_response,
-            mock_delete_response,
-            mock_delete_response,
-        ],
-    )
-
+@pytest.mark.vcr()
+def test_move_pages(client, page_id):
     target_parent = client.pages.create(
-        parent={"page_id": "root-page-123"},
+        parent={"page_id": page_id},
         properties={"title": [{"text": {"content": "Target Parent"}}]},
     )
 
     page_to_move = client.pages.create(
-        parent={"page_id": "root-page-123"},
+        parent={"page_id": page_id},
         properties={"title": [{"text": {"content": "Moving Page"}}]},
     )
 
@@ -621,5 +584,3 @@ def test_move_pages(client, mocker):
 
     client.blocks.delete(block_id=page_to_move["id"])
     client.blocks.delete(block_id=target_parent["id"])
-
-    assert mock_request.call_count == 5


### PR DESCRIPTION
## Description
Add `pages.move()` method to move Notion pages to new parent locations.

## Changes
- Add `move()` method to `PagesEndpoint` class
- Use `PATCH /pages/{page_id}` endpoint  
- Support moving pages to new page or database parents
- Add unit test `test_move_pages` with mocked API calls

## Testing
```bash
python3 -m pytest tests/test_endpoints.py::test_move_pages -v
```
✅ All tests pass (125 passed)
✅ Coverage remains at 100%
✅ Pre-commit hooks pass

## References
- Notion API docs: https://developers.notion.com/reference/patch-page
- Implements functionality from JS SDK