### PR TITLE
Add `pages.retrieve_markdown()` and `pages.update_markdown()` endpoints

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -273,6 +273,7 @@ class PagesEndpoint(Endpoint):
                 "cover",
                 "content",
                 "children",
+                "markdown",
                 "template",
                 "position",
             ),
@@ -310,6 +311,30 @@ class PagesEndpoint(Endpoint):
                 "archived",
                 "in_trash",
             ),
+            auth=kwargs.get("auth"),
+        )
+
+    def retrieve_markdown(self, page_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Retrieve a page as markdown.
+
+        *[🔗 Endpoint documentation](https://developers.notion.com/reference/retrieve-page-markdown)*
+        """  # noqa: E501
+        return self.parent.request(
+            path=f"pages/{page_id}/markdown",
+            method="GET",
+            query=pick(kwargs, "include_transcript"),
+            auth=kwargs.get("auth"),
+        )
+
+    def update_markdown(self, page_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Update a page's content as markdown.
+
+        *[🔗 Endpoint documentation](https://developers.notion.com/reference/update-page-markdown)*
+        """  # noqa: E501
+        return self.parent.request(
+            path=f"pages/{page_id}/markdown",
+            method="PATCH",
+            body=pick(kwargs, "type", "insert_content", "replace_content_range"),
             auth=kwargs.get("auth"),
         )
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -228,6 +228,61 @@ def test_comments_retrieve(client, comment_id):
     assert response["id"] == comment_id
 
 
+# Markdown endpoints require a public (OAuth) integration, so we can't record cassettes
+# with our internal integration token. Using mocks instead.
+def test_pages_retrieve_markdown(client, mocker):
+    mock_response = {
+        "object": "page_markdown",
+        "id": "abc123",
+        "markdown": "# Hello",
+        "truncated": False,
+        "unknown_block_ids": [],
+    }
+    mock_request = mocker.patch.object(client, "request", return_value=mock_response)
+
+    response = client.pages.retrieve_markdown(page_id="abc123", include_transcript=True)
+
+    assert response["object"] == "page_markdown"
+    mock_request.assert_called_once_with(
+        path="pages/abc123/markdown",
+        method="GET",
+        query={"include_transcript": True},
+        auth=None,
+    )
+
+
+# Markdown endpoints require a public (OAuth) integration, so we can't record cassettes
+# with our internal integration token. Using mocks instead.
+def test_pages_update_markdown(client, mocker):
+    mock_response = {
+        "object": "page_markdown",
+        "id": "abc123",
+        "markdown": "## New Section\n\nHello from markdown.",
+        "truncated": False,
+        "unknown_block_ids": [],
+    }
+    mock_request = mocker.patch.object(client, "request", return_value=mock_response)
+
+    response = client.pages.update_markdown(
+        page_id="abc123",
+        type="insert_content",
+        insert_content={"content": "## New Section\n\nHello from markdown."},
+    )
+
+    assert response["object"] == "page_markdown"
+    mock_request.assert_called_once_with(
+        path="pages/abc123/markdown",
+        method="PATCH",
+        body={
+            "type": "insert_content",
+            "insert_content": {
+                "content": "## New Section\n\nHello from markdown.",
+            },
+        },
+        auth=None,
+    )
+
+
 @pytest.mark.vcr()
 def test_pages_delete(client, page_id):
     response = client.blocks.delete(block_id=page_id)


### PR DESCRIPTION
Following https://github.com/makenotion/notion-sdk-js/pull/669, add support for the new markdown content endpoints and allow passing `markdown` to `pages.create()`.
