### PR TITLE
Handle trailing slashes in get_id URLs

### DIFF
--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -38,7 +38,7 @@ def get_id(url: str) -> str:
     parsed = urlparse(url)
     if parsed.netloc not in ("notion.so", "www.notion.so"):
         raise ValueError("Not a valid Notion URL.")
-    path = parsed.path
+    path = parsed.path.rstrip("/")
     if len(path) < 32:
         raise ValueError("The path in the URL seems to be incorrect.")
     raw_id = path[-32:]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -56,6 +56,7 @@ def test_get_id():
             v=f41969f937614159857f6a5725990649"
     db_id = "99572135-4646-49bd-95a1-4ff08f79c7a5"
     assert get_id(page_url) == page_id
+    assert get_id(f"{page_url}/") == page_id
     assert get_id(db_url) == db_id
     with pytest.raises(ValueError):
         get_id("https://example.com")


### PR DESCRIPTION
## What changed

`get_id()` now strips trailing slashes from the parsed URL path before taking the final 32-character Notion ID segment.

## Why

Notion page URLs are commonly copied with a trailing `/`. The previous implementation included that slash in the final 32 characters, which caused `UUID(...)` validation to fail even though the URL otherwise contained a valid page ID.

## Validation

- `python -m pytest tests\test_helpers.py::test_get_id -q --no-cov`
- `python -m compileall -q notion_client tests\test_helpers.py`
- `git diff --check`

I also ran `python -m flake8 notion_client\helpers.py tests\test_helpers.py`; it reports pre-existing E501 long lines in these files that are unrelated to this change.