### PR TITLE
Add `client.async_tasks.retrieve()` and `allow_async` support

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -284,6 +284,7 @@ class PagesEndpoint(Endpoint):
             method="POST",
             body=pick(
                 kwargs,
+                "allow_async",
                 "parent",
                 "properties",
                 "icon",
@@ -353,6 +354,7 @@ class PagesEndpoint(Endpoint):
             method="PATCH",
             body=pick(
                 kwargs,
+                "allow_async",
                 "type",
                 "insert_content",
                 "replace_content_range",
@@ -623,6 +625,19 @@ class CommentsEndpoint(Endpoint):
         return self.parent.request(
             path=f"comments/{comment_id}",
             method="DELETE",
+            auth=kwargs.get("auth"),
+        )
+
+
+class AsyncTasksEndpoint(Endpoint):
+    def retrieve(self, task_id: str, **kwargs: Any) -> SyncAsync[Any]:
+        """Retrieve the status and result of an async task.
+
+        *[🔗 Endpoint documentation](https://developers.notion.com/reference/retrieve-async-task)*
+        """  # noqa: E501
+        return self.parent.request(
+            path=f"async_tasks/{task_id}",
+            method="GET",
             auth=kwargs.get("auth"),
         )
 

--- a/notion_client/client.py
+++ b/notion_client/client.py
@@ -23,6 +23,7 @@ from notion_client.constants import (
     DEFAULT_MAX_RETRY_DELAY_MS,
 )
 from notion_client.api_endpoints import (
+    AsyncTasksEndpoint,
     BlocksEndpoint,
     CommentsEndpoint,
     CustomEmojisEndpoint,
@@ -135,6 +136,7 @@ class BaseClient:
         self.views = ViewsEndpoint(self)
         self.search = SearchEndpoint(self)
         self.comments = CommentsEndpoint(self)
+        self.async_tasks = AsyncTasksEndpoint(self)
         self.file_uploads = FileUploadsEndpoint(self)
         self.oauth = OAuthEndpoint(self)
 

--- a/tests/cassettes/test_async_tasks_retrieve.yaml
+++ b/tests/cassettes/test_async_tasks_retrieve.yaml
@@ -1,0 +1,129 @@
+interactions:
+- request:
+    body: '{"parent":{"page_id":"393abc1eedcd80f3813be205934558c6"},"properties":{"title":[{"text":{"content":"Test
+      2026-07-04 12:07:00.740947"}}]},"children":[]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - ntn_...
+      connection:
+      - keep-alive
+      content-length:
+      - '151'
+      content-type:
+      - application/json
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    body:
+      string: '{"object":"page","id":"393abc1e-edcd-814e-95ce-db661df73290","created_time":"2026-07-04T10:07:00.000Z","last_edited_time":"2026-07-04T10:07:00.000Z","created_by":{"object":"user","id":"7775f3a3-893f-43fa-b625-460c61094c78"},"last_edited_by":{"object":"user","id":"7775f3a3-893f-43fa-b625-460c61094c78"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"393abc1e-edcd-80f3-813b-e205934558c6"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Test
+        2026-07-04 12:07:00.740947","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Test
+        2026-07-04 12:07:00.740947","href":null}]}},"url":"https://app.notion.com/p/Test-2026-07-04-12-07-00-740947-393abc1eedcd814e95cedb661df73290","public_url":null,"archived":false,"request_id":"5385b36f-2290-464c-9a96-c399dbec3a73"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '963'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"allow_async":true,"type":"insert_content","insert_content":{"content":"#
+      Hello\n\nAsync test content."}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - ntn_...
+      connection:
+      - keep-alive
+      content-length:
+      - '106'
+      content-type:
+      - application/json
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: PATCH
+    uri: https://api.notion.com/v1/pages/393abc1e-edcd-814e-95ce-db661df73290/markdown
+  response:
+    body:
+      string: '{"object":"async_task","id":"task_7e869d57816e45acb1b9a499db3d2a99","status":"queued","status_url":"https://api.notion.com/v1/async_tasks/task_7e869d57816e45acb1b9a499db3d2a99","created_time":"2026-07-04T10:07:01.549Z","poll_after_seconds":2,"operation":{"surface":"rest","name":"PATCH
+        /v1/pages/:page_id/markdown"},"request_id":"a6255b38-6df2-42c4-9529-ac9b9ac27b95"}'
+    headers:
+      Content-Length:
+      - '368'
+      Content-Type:
+      - application/json; charset=utf-8
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - ntn_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: GET
+    uri: https://api.notion.com/v1/async_tasks/task_7e869d57816e45acb1b9a499db3d2a99
+  response:
+    body:
+      string: '{"object":"async_task","id":"task_7e869d57816e45acb1b9a499db3d2a99","status":"succeeded","status_url":"https://api.notion.com/v1/async_tasks/task_7e869d57816e45acb1b9a499db3d2a99","created_time":"2026-07-04T10:07:01.786Z","operation":{"surface":"rest","name":"PATCH
+        /v1/pages/:page_id/markdown"},"result":{"markdown":"# Hello\nAsync test content.","truncated":false,"unknown_block_ids":[],"id":"393abc1e-edcd-814e-95ce-db661df73290","object":"page_markdown"},"request_id":"460c9b64-5bb0-4118-a8ad-a8fa85694c4e"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '511'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - ntn_...
+      connection:
+      - keep-alive
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/393abc1e-edcd-814e-95ce-db661df73290
+  response:
+    body:
+      string: '{"object":"block","id":"393abc1e-edcd-814e-95ce-db661df73290","parent":{"type":"page_id","page_id":"393abc1e-edcd-80f3-813b-e205934558c6"},"created_time":"2026-07-04T10:07:00.000Z","last_edited_time":"2026-07-04T10:07:00.000Z","created_by":{"object":"user","id":"7775f3a3-893f-43fa-b625-460c61094c78"},"last_edited_by":{"object":"user","id":"7775f3a3-893f-43fa-b625-460c61094c78"},"has_children":true,"in_trash":true,"type":"child_page","child_page":{"title":"Test
+        2026-07-04 12:07:00.740947"},"archived":true,"request_id":"8f3d8667-6a5f-403a-8471-9d96ce5ac1ff"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      content-length:
+      - '562'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -362,6 +362,22 @@ def test_pages_update_markdown(client, page_id):
 
 
 @pytest.mark.vcr()
+def test_async_tasks_retrieve(client, page_id):
+    update_response = client.pages.update_markdown(
+        page_id=page_id,
+        type="insert_content",
+        insert_content={"content": "# Hello\n\nAsync test content."},
+        allow_async=True,
+    )
+    assert update_response["object"] == "async_task"
+    task_id = update_response["id"]
+
+    response = client.async_tasks.retrieve(task_id=task_id)
+    assert response["object"] == "async_task"
+    assert response["id"] == task_id
+
+
+@pytest.mark.vcr()
 def test_pages_delete(client, page_id):
     response = client.blocks.delete(block_id=page_id)
     assert response


### PR DESCRIPTION
Notion now offers async responses for large markdown page create/update requests.

https://github.com/makenotion/notion-sdk-js/pull/728
https://github.com/makenotion/notion-sdk-js/pull/729
https://github.com/makenotion/notion-sdk-js/pull/736
