### PR TITLE
examples: port parse-text-from-any-block-type from JS SDK

### DIFF
--- a/examples/parse_text_from_any_block_type/.env.example
+++ b/examples/parse_text_from_any_block_type/.env.example
@@ -1,0 +1,2 @@
+NOTION_API_KEY=<your-notion-api-key>
+NOTION_PAGE_ID=<notion-page-id>

--- a/examples/parse_text_from_any_block_type/README.md
+++ b/examples/parse_text_from_any_block_type/README.md
@@ -1,14 +1,23 @@
 # Parse text from any block type
 
-Extract plain text from any type of Notion block, including headers, lists, media, and more.
+Extract plain text from any type of Notion block,
+including headers, lists, media, and more.
 
 ## About
 
-This example retrieves [page content](https://developers.notion.com/docs/working-with-page-content) (represented as [blocks](https://developers.notion.com/docs/working-with-page-content#modeling-content-as-blocks)) and extracts plain text from each block. The text is printed to the console, but can be used in your projects as needed.
+This example retrieves
+[page content](https://developers.notion.com/docs/working-with-page-content)
+(represented as
+[blocks](https://developers.notion.com/docs/working-with-page-content#modeling-content-as-blocks))
+and extracts plain text from each block. The text is printed to the
+console, but can be used in your projects as needed.
 
-When retrieving block children with the public API, the block structure varies by type. This example handles the different block shapes and extracts available text in a uniform way.
+When retrieving block children with the public API,
+the block structure varies by type. This example handles the
+different block shapes and extracts available text in a uniform way.
 
-**Note:** Not all blocks contain text (e.g., dividers), and some block types may not yet be supported by the public API.
+**Note:** Not all blocks contain text (e.g., dividers),
+and some block types may not yet be supported by the public API.
 
 ## Running locally
 
@@ -33,7 +42,7 @@ pip install python-dotenv
 
 Copy `.env.example` to `.env` and fill in your values:
 
-```
+```env
 NOTION_API_KEY=<your-notion-api-key>
 NOTION_PAGE_ID=<notion-page-id>
 ```

--- a/examples/parse_text_from_any_block_type/README.md
+++ b/examples/parse_text_from_any_block_type/README.md
@@ -1,0 +1,55 @@
+# Parse text from any block type
+
+Extract plain text from any type of Notion block, including headers, lists, media, and more.
+
+## About
+
+This example retrieves [page content](https://developers.notion.com/docs/working-with-page-content) (represented as [blocks](https://developers.notion.com/docs/working-with-page-content#modeling-content-as-blocks)) and extracts plain text from each block. The text is printed to the console, but can be used in your projects as needed.
+
+When retrieving block children with the public API, the block structure varies by type. This example handles the different block shapes and extracts available text in a uniform way.
+
+**Note:** Not all blocks contain text (e.g., dividers), and some block types may not yet be supported by the public API.
+
+## Running locally
+
+### 1. Install dependencies
+
+```bash
+pip install notion-client
+```
+
+Optionally install `python-dotenv` to load environment variables from a `.env` file:
+
+```bash
+pip install python-dotenv
+```
+
+### 2. Set up your Notion integration
+
+1. Create a new integration in the [integrations dashboard](https://www.notion.com/my-integrations)
+2. Copy the API key ("Internal Integration Token") from the Secrets page
+
+### 3. Set environment variables
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```
+NOTION_API_KEY=<your-notion-api-key>
+NOTION_PAGE_ID=<notion-page-id>
+```
+
+The page ID is the 32-character string at the end of any Notion page URL:
+`https://www.notion.so/My-Page-<page_id>`
+
+### 4. Share the page with your integration
+
+1. Open the page in Notion
+2. Click the `•••` menu in the top-right corner
+3. Scroll down and click `Add connections`
+4. Search for and select your integration
+
+### 5. Run the script
+
+```bash
+python parse_text_from_any_block_type.py
+```

--- a/examples/parse_text_from_any_block_type/parse_text_from_any_block_type.py
+++ b/examples/parse_text_from_any_block_type/parse_text_from_any_block_type.py
@@ -91,9 +91,7 @@ def get_text_from_block(block):
 def retrieve_block_children(page_id):
     print("Retrieving blocks...")
     blocks = []
-    for block in iterate_paginated_api(
-        notion.blocks.children.list, block_id=page_id
-    ):
+    for block in iterate_paginated_api(notion.blocks.children.list, block_id=page_id):
         blocks.append(block)
     return blocks
 

--- a/examples/parse_text_from_any_block_type/parse_text_from_any_block_type.py
+++ b/examples/parse_text_from_any_block_type/parse_text_from_any_block_type.py
@@ -1,0 +1,114 @@
+import os
+
+from notion_client import Client
+from notion_client.helpers import iterate_paginated_api
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:
+    pass
+else:
+    load_dotenv()
+
+NOTION_API_KEY = os.getenv("NOTION_API_KEY", "")
+NOTION_PAGE_ID = os.getenv("NOTION_PAGE_ID", "")
+
+while NOTION_API_KEY == "":
+    NOTION_API_KEY = input("Enter your Notion integration token: ").strip()
+
+while NOTION_PAGE_ID == "":
+    NOTION_PAGE_ID = input("Enter the Notion page ID: ").strip()
+
+notion = Client(auth=NOTION_API_KEY)
+
+
+def get_plain_text_from_rich_text(rich_text):
+    return "".join(t.get("plain_text", "") for t in rich_text)
+
+
+def get_media_source_text(block):
+    block_type = block["type"]
+    block_data = block[block_type]
+
+    if "external" in block_data:
+        source = block_data["external"]["url"]
+    elif "file" in block_data:
+        source = block_data["file"]["url"]
+    elif "url" in block_data:
+        source = block_data["url"]
+    else:
+        source = f"[Missing case for media block types]: {block_type}"
+
+    if block_data.get("caption"):
+        caption = get_plain_text_from_rich_text(block_data["caption"])
+        return f"{caption}: {source}"
+    return source
+
+
+def get_text_from_block(block):
+    block_type = block["type"]
+    block_data = block[block_type]
+
+    if "rich_text" in block_data:
+        text = get_plain_text_from_rich_text(block_data["rich_text"])
+    else:
+        if block_type == "unsupported":
+            text = "[Unsupported block type]"
+        elif block_type == "bookmark":
+            text = block_data["url"]
+        elif block_type == "child_database":
+            text = block_data["title"]
+        elif block_type == "child_page":
+            text = block_data["title"]
+        elif block_type in ("embed", "video", "file", "image", "pdf"):
+            text = get_media_source_text(block)
+        elif block_type == "equation":
+            text = block_data["expression"]
+        elif block_type == "link_preview":
+            text = block_data["url"]
+        elif block_type == "synced_block":
+            synced_from = block_data.get("synced_from")
+            if synced_from:
+                source_type = synced_from["type"]
+                text = f"This block is synced with a block with the following ID: {synced_from[source_type]}"
+            else:
+                text = "Source sync block that another block is synced with."
+        elif block_type == "table":
+            text = f"Table width: {block_data['table_width']}"
+        elif block_type == "table_of_contents":
+            text = f"ToC color: {block_data['color']}"
+        elif block_type in ("breadcrumb", "column_list", "divider"):
+            text = "No text available"
+        else:
+            text = "[Needs case added]"
+
+    if block.get("has_children"):
+        text = f"{text} (Has children)"
+
+    return f"{block_type}: {text}"
+
+
+def retrieve_block_children(page_id):
+    print("Retrieving blocks...")
+    blocks = []
+    for block in iterate_paginated_api(
+        notion.blocks.children.list, block_id=page_id
+    ):
+        blocks.append(block)
+    return blocks
+
+
+def print_block_text(blocks):
+    print("Displaying blocks:")
+    for i, block in enumerate(blocks, 1):
+        text = get_text_from_block(block)
+        print(f"{i}. {text}")
+
+
+def main():
+    blocks = retrieve_block_children(NOTION_PAGE_ID)
+    print_block_text(blocks)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replicates the notion-sdk-js example that extracts plain text from any block type.

## Changes
- New \examples/parse_text_from_any_block_type/\ directory
- \parse_text_from_any_block_type.py\ — main script handling all block types
- \README.md\ — setup instructions following existing conventions
- \.env.example\ — environment variable template

Implements one of the remaining examples from issue #278.