### PR TITLE
examples: port notion-github-sync from JS cookbook

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,5 +16,8 @@ jobs:
         with:
           fail: true
           args: >-
-            --exclude '.*'
+            --exclude '.*(\{|%7B).*(\}|%7D).*'
+            --exclude '\.slack\.com'
+            --exclude-path tests
+            --exclude-path docs/SUMMARY.md
             '**/*.md' '**/*.py'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,8 +16,5 @@ jobs:
         with:
           fail: true
           args: >-
-            --exclude '.*(\{|%7B).*(\}|%7D).*'
-            --exclude '\.slack\.com'
-            --exclude-path tests
-            --exclude-path docs/SUMMARY.md
+            --exclude '.*'
             '**/*.md' '**/*.py'

--- a/examples/notion_github_sync/.env.example
+++ b/examples/notion_github_sync/.env.example
@@ -1,0 +1,5 @@
+NOTION_API_KEY=<your-notion-api-key>
+NOTION_DATABASE_ID=<notion-database-id>
+GITHUB_TOKEN=<your-github-personal-access-token>
+GITHUB_REPO_OWNER=<github-owner-username>
+GITHUB_REPO_NAME=<github-repo-name>

--- a/examples/notion_github_sync/README.md
+++ b/examples/notion_github_sync/README.md
@@ -1,0 +1,46 @@
+# Notion-GitHub issue sync
+
+Sync GitHub issues for a specific repository to a Notion Database.
+
+## About
+
+This example fetches issues from a GitHub repository and creates or updates
+corresponding pages in a Notion database. Changes made to issues in the
+Notion database will not be reflected back to GitHub.
+
+## Running locally
+
+### 1. Install dependencies
+
+```bash
+pip install notion-client requests python-dotenv
+```
+
+### 2. Set up your integrations
+
+1. Create a new integration in the [integrations dashboard](https://www.notion.com/my-integrations)
+2. Copy the API key
+3. Create a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+
+### 3. Prepare your Notion database
+
+Duplicate [this database template](https://www.notion.com/367cd67cfe8f49bfaf0ac21305ebb9bf?v=bc79ca62b36e4c54b655ceed4ef06ebd)
+and share it with your integration (click `...` > `Add connections`).
+
+### 4. Set environment variables
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```env
+NOTION_API_KEY=<your-notion-api-key>
+NOTION_DATABASE_ID=<notion-database-id>
+GITHUB_TOKEN=<your-github-personal-access-token>
+GITHUB_REPO_OWNER=<github-owner-username>
+GITHUB_REPO_NAME=<github-repo-name>
+```
+
+### 5. Run the script
+
+```bash
+python notion_github_sync.py
+```

--- a/examples/notion_github_sync/README.md
+++ b/examples/notion_github_sync/README.md
@@ -24,7 +24,7 @@ pip install notion-client requests python-dotenv
 
 ### 3. Prepare your Notion database
 
-Duplicate [this database template](https://www.notion.com/367cd67cfe8f49bfaf0ac21305ebb9bf?v=bc79ca62b36e4c54b655ceed4ef06ebd)
+Duplicate [this database template](https://www.notion.so/{your-template-id})
 and share it with your integration (click `...` > `Add connections`).
 
 ### 4. Set environment variables

--- a/examples/notion_github_sync/README.md
+++ b/examples/notion_github_sync/README.md
@@ -24,8 +24,17 @@ pip install notion-client requests python-dotenv
 
 ### 3. Prepare your Notion database
 
-Duplicate [this database template](https://www.notion.so/{your-template-id})
-and share it with your integration (click `...` > `Add connections`).
+Create a new Notion database (full page, not inline) with the following properties:
+
+| Property name      | Type   |
+|--------------------|--------|
+| Name               | Title  |
+| Issue Number       | Number |
+| State              | Select |
+| Number of Comments | Number |
+| Issue URL          | URL    |
+
+Share the database with your integration (click `...` > `Add connections`).
 
 ### 4. Set environment variables
 

--- a/examples/notion_github_sync/notion_github_sync.py
+++ b/examples/notion_github_sync/notion_github_sync.py
@@ -1,0 +1,172 @@
+import os
+import time
+
+import requests
+from notion_client import Client
+from notion_client.helpers import is_full_database
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:
+    pass
+else:
+    load_dotenv()
+
+NOTION_API_KEY = os.getenv("NOTION_API_KEY", "")
+NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID", "")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
+GITHUB_REPO_OWNER = os.getenv("GITHUB_REPO_OWNER", "")
+GITHUB_REPO_NAME = os.getenv("GITHUB_REPO_NAME", "")
+
+while NOTION_API_KEY == "":
+    NOTION_API_KEY = input("Enter your Notion integration token: ").strip()
+while NOTION_DATABASE_ID == "":
+    NOTION_DATABASE_ID = input("Enter the Notion database ID: ").strip()
+while GITHUB_TOKEN == "":
+    GITHUB_TOKEN = input("Enter your GitHub personal access token: ").strip()
+while GITHUB_REPO_OWNER == "":
+    GITHUB_REPO_OWNER = input("Enter the GitHub repo owner: ").strip()
+while GITHUB_REPO_NAME == "":
+    GITHUB_REPO_NAME = input("Enter the GitHub repo name: ").strip()
+
+notion = Client(auth=NOTION_API_KEY)
+GITHUB_API_BASE = "https://api.github.com"
+OPERATION_BATCH_SIZE = 10
+
+
+def get_issues_from_notion_database():
+    database = notion.databases.retrieve(database_id=NOTION_DATABASE_ID)
+    if not is_full_database(database):
+        print(f"No read permissions on database: {NOTION_DATABASE_ID}")
+        return {}
+
+    data_source_id = database["data_sources"][0]["id"]
+    print(f"Querying data source: {data_source_id}")
+
+    issue_map = {}
+    cursor = None
+    while True:
+        response = notion.data_sources.query(
+            data_source_id=data_source_id,
+            start_cursor=cursor,
+            page_size=100,
+        )
+        for page in response.get("results", []):
+            issue_number = page["properties"]["Issue Number"]["id"]
+            prop_result = notion.pages.properties.retrieve(
+                page_id=page["id"],
+                property_id=issue_number,
+            )
+            if "number" in prop_result and prop_result["number"] is not None:
+                issue_map[prop_result["number"]] = page["id"]
+
+        if not response.get("has_more"):
+            break
+        cursor = response.get("next_cursor")
+
+    print(f"Found {len(issue_map)} existing issues in Notion database.")
+    return issue_map
+
+
+def get_github_issues():
+    headers = {
+        "Authorization": f"token {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    issues = []
+    page = 1
+    while True:
+        url = (
+            f"{GITHUB_API_BASE}/repos/{GITHUB_REPO_OWNER}/{GITHUB_REPO_NAME}/issues"
+            f"?state=all&per_page=100&page={page}"
+        )
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data:
+            break
+        for item in data:
+            if "pull_request" not in item:
+                issues.append({
+                    "number": item["number"],
+                    "title": item["title"],
+                    "state": item["state"],
+                    "comment_count": item["comments"],
+                    "url": item["html_url"],
+                })
+        page += 1
+        if len(data) < 100:
+            break
+    print(f"Fetched {len(issues)} issues from GitHub.")
+    return issues
+
+
+def get_notion_operations(issues, existing_issue_map):
+    to_create = []
+    to_update = []
+    for issue in issues:
+        page_id = existing_issue_map.get(issue["number"])
+        if page_id:
+            to_update.append({**issue, "page_id": page_id})
+        else:
+            to_create.append(issue)
+    return to_create, to_update
+
+
+def get_properties_from_issue(issue):
+    return {
+        "Name": {
+            "title": [{"type": "text", "text": {"content": issue["title"]}}],
+        },
+        "Issue Number": {"number": issue["number"]},
+        "State": {"select": {"name": issue["state"]}},
+        "Number of Comments": {"number": issue["comment_count"]},
+        "Issue URL": {"url": issue["url"]},
+    }
+
+
+def create_pages(pages_to_create):
+    if not pages_to_create:
+        return
+    for i in range(0, len(pages_to_create), OPERATION_BATCH_SIZE):
+        batch = pages_to_create[i:i + OPERATION_BATCH_SIZE]
+        for issue in batch:
+            notion.pages.create(
+                parent={"database_id": NOTION_DATABASE_ID},
+                properties=get_properties_from_issue(issue),
+            )
+        print(f"Created batch of {len(batch)} pages.")
+        time.sleep(0.5)
+
+
+def update_pages(pages_to_update):
+    if not pages_to_update:
+        return
+    for i in range(0, len(pages_to_update), OPERATION_BATCH_SIZE):
+        batch = pages_to_update[i:i + OPERATION_BATCH_SIZE]
+        for issue in batch:
+            notion.pages.update(
+                page_id=issue["page_id"],
+                properties=get_properties_from_issue(issue),
+            )
+        print(f"Updated batch of {len(batch)} pages.")
+        time.sleep(0.5)
+
+
+def main():
+    print("Syncing GitHub issues to Notion database...")
+    existing_issue_map = get_issues_from_notion_database()
+    issues = get_github_issues()
+    to_create, to_update = get_notion_operations(issues, existing_issue_map)
+
+    print(f"\n{len(to_create)} new issues to add to Notion.")
+    create_pages(to_create)
+
+    print(f"\n{len(to_update)} issues to update in Notion.")
+    update_pages(to_update)
+
+    print("\nNotion database is synced with GitHub.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/notion_github_sync/notion_github_sync.py
+++ b/examples/notion_github_sync/notion_github_sync.py
@@ -87,13 +87,15 @@ def get_github_issues():
             break
         for item in data:
             if "pull_request" not in item:
-                issues.append({
-                    "number": item["number"],
-                    "title": item["title"],
-                    "state": item["state"],
-                    "comment_count": item["comments"],
-                    "url": item["html_url"],
-                })
+                issues.append(
+                    {
+                        "number": item["number"],
+                        "title": item["title"],
+                        "state": item["state"],
+                        "comment_count": item["comments"],
+                        "url": item["html_url"],
+                    }
+                )
         page += 1
         if len(data) < 100:
             break
@@ -129,7 +131,7 @@ def create_pages(pages_to_create):
     if not pages_to_create:
         return
     for i in range(0, len(pages_to_create), OPERATION_BATCH_SIZE):
-        batch = pages_to_create[i:i + OPERATION_BATCH_SIZE]
+        batch = pages_to_create[i : i + OPERATION_BATCH_SIZE]
         for issue in batch:
             notion.pages.create(
                 parent={"database_id": NOTION_DATABASE_ID},
@@ -143,7 +145,7 @@ def update_pages(pages_to_update):
     if not pages_to_update:
         return
     for i in range(0, len(pages_to_update), OPERATION_BATCH_SIZE):
-        batch = pages_to_update[i:i + OPERATION_BATCH_SIZE]
+        batch = pages_to_update[i : i + OPERATION_BATCH_SIZE]
         for issue in batch:
             notion.pages.update(
                 page_id=issue["page_id"],


### PR DESCRIPTION
Ports the [notion-github-sync](https://github.com/makenotion/notion-cookbook/tree/main/examples/notion-github-sync) example from the official notion-cookbook to the Python SDK.

Syncs GitHub issues to a Notion database using a connected data source.