### PR TITLE
Accept notion.com in the URL helpers

### DIFF
--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -33,10 +33,22 @@ def get_url(object_id: str) -> str:
     return f"https://notion.so/{UUID(object_id).hex}"
 
 
+#: Registrable domains Notion serves object URLs from. `notion.com` is the one the API
+#: returns today (`page["url"]` is `https://app.notion.com/...`); `notion.so` is the legacy
+#: host and still resolves; `notion.site` serves published pages.
+_NOTION_DOMAINS = ("notion.com", "notion.so", "notion.site")
+
+
+def _is_notion_host(netloc: str) -> bool:
+    """Return `True` for a Notion domain or any of its subdomains (app., www., ...)."""
+    host = netloc.lower().partition(":")[0]
+    return any(host == d or host.endswith(f".{d}") for d in _NOTION_DOMAINS)
+
+
 def get_id(url: str) -> str:
     """Return the id of the object behind the given URL."""
     parsed = urlparse(url)
-    if parsed.netloc not in ("notion.so", "www.notion.so"):
+    if not _is_notion_host(parsed.netloc):
         raise ValueError("Not a valid Notion URL.")
     path = parsed.path.rstrip("/")
     if len(path) < 32:
@@ -191,9 +203,14 @@ def extract_notion_id(url_or_id: str) -> Optional[str]:
     if compact_uuid_pattern.match(trimmed):
         return _format_uuid(trimmed.lower())
 
-    # For URLs, check if it's a valid Notion domain
+    # For URLs, check if it's a valid Notion domain. This function is documented to
+    # return None rather than raise for any invalid input, so a parse failure is a None.
     if "://" in trimmed:
-        if not re.search(r"://(?:www\.)?notion\.(?:so|site)/", trimmed, re.IGNORECASE):
+        try:
+            netloc = urlparse(trimmed).netloc
+        except Exception:  # noqa: BLE001
+            return None
+        if not _is_notion_host(netloc):
             return None
 
     # Fallback to query parameters if no direct ID found

--- a/tests/test_helpers_url_hosts.py
+++ b/tests/test_helpers_url_hosts.py
@@ -1,0 +1,75 @@
+"""The URL helpers must accept the host the Notion API actually returns.
+
+Every object URL in this repo's own recorded cassettes is on `app.notion.com`, and the same
+files carried `www.notion.so` before they were re-recorded. `get_id` raised and
+`extract_notion_id` returned None for those URLs.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+import notion_client
+from notion_client.helpers import extract_notion_id, extract_page_id, get_id
+
+# Verbatim from tests/cassettes/, where it is the only object-URL host present.
+API_PAGE_URL = "https://app.notion.com/p/393abc1eedcd80f3813be205934558c6"
+EXPECTED_ID = "393abc1e-edcd-80f3-813b-e205934558c6"
+
+
+def test_cassettes_really_do_use_this_host():
+    """Guard: if the recorded responses stop using app.notion.com, the tests below are
+    asserting against a host the API no longer returns and should be revisited. Without
+    this the suite could keep passing while measuring nothing."""
+    cassettes = pathlib.Path(notion_client.__file__).parents[1] / "tests" / "cassettes"
+    hosts = set()
+    for f in cassettes.glob("*.yaml"):
+        hosts.update(
+            re.findall(
+                r'"(?:url|public_url)":"https://([^/"]+)', f.read_text(errors="ignore")
+            )
+        )
+    assert hosts, (
+        "no object URLs found in the cassettes; this test is measuring nothing"
+    )
+    assert hosts == {"app.notion.com"}, hosts
+
+
+def test_get_id_accepts_the_host_the_api_returns():
+    assert get_id(API_PAGE_URL) == EXPECTED_ID
+
+
+def test_extract_notion_id_accepts_the_host_the_api_returns():
+    assert extract_notion_id(API_PAGE_URL) == EXPECTED_ID
+    assert extract_page_id(API_PAGE_URL) == EXPECTED_ID
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://notion.so/" + "a" * 32,
+        "https://www.notion.so/" + "a" * 32,
+        "https://app.notion.com/" + "a" * 32,
+    ],
+)
+def test_notion_hosts_are_accepted(url):
+    assert get_id(url) == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    assert extract_notion_id(url) == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.com/" + "a" * 32,
+        "https://notion.so.evil.com/" + "a" * 32,
+        "https://notion.com.evil.com/" + "a" * 32,
+        "https://notsonotion.com/" + "a" * 32,
+    ],
+)
+def test_non_notion_hosts_are_still_rejected(url):
+    """The widened allowlist must not become a suffix match. These pass before the change
+    and must keep passing after it."""
+    with pytest.raises(ValueError):
+        get_id(url)
+    assert extract_notion_id(url) is None

--- a/tests/test_helpers_url_hosts.py
+++ b/tests/test_helpers_url_hosts.py
@@ -30,9 +30,9 @@ def test_cassettes_really_do_use_this_host():
                 r'"(?:url|public_url)":"https://([^/"]+)', f.read_text(errors="ignore")
             )
         )
-    assert hosts, (
-        "no object URLs found in the cassettes; this test is measuring nothing"
-    )
+    assert (
+        hosts
+    ), "no object URLs found in the cassettes; this test is measuring nothing"
     assert hosts == {"app.notion.com"}, hosts
 
 


### PR DESCRIPTION
`get_id` accepts only `notion.so` and `www.notion.so`, and `extract_notion_id` only matches `notion.so` or `notion.site`. Notion serves object URLs from `app.notion.com`, so `get_id(page["url"])` raises `ValueError` on the URL the API just handed you, and `extract_notion_id` returns `None` for it without saying why.

The evidence is in this repo. Every object URL in the recorded cassettes is on `app.notion.com`:

```
$ grep -ohE '"(url|public_url)":"https://[^/"]+' tests/cassettes/*.yaml | sed 's|.*https://||' | sort | uniq -c
  98 app.notion.com
```

Those same files carried `www.notion.so` before the cassettes were re-recorded against the live API in July. The allowlist has not been touched since "Fix get_url (#80)", so this reads as the host moving underneath it, not a deliberate restriction.

Both helpers now share `_is_notion_host`, which accepts `notion.com`, `notion.so` and `notion.site` and any subdomain of them.

The part worth reviewing is that this does not become a suffix match. `notion.so.evil.com`, `notion.com.evil.com`, `notsonotion.com` and `evil.com` are all rejected before and after, and those cases are in the tests so the guarantee is pinned, not argued. `extract_notion_id` still returns `None` instead of raising on unparseable input, which is the contract `test_extract_block_id_url_parsing_exception` already covers.

One test asserts the cassettes really are all on `app.notion.com`, so if that ever changes this fails loudly instead of passing for the wrong reason.

Three of the ten new tests fail on `main` and all ten pass here. Full suite is 202. Coverage on `helpers.py` stays at 100%, and `get_url()` is untouched, so nothing changes about the host we emit.

I do not have a Notion account, so this rests on your recorded responses, not on live calls I made.
