### PR TITLE
Terminate the paginators on the cursor alone, as the JS SDK does

### DIFF
--- a/notion_client/helpers.py
+++ b/notion_client/helpers.py
@@ -57,7 +57,7 @@ def iterate_paginated_api(
             yield result
 
         next_cursor = response.get("next_cursor")
-        if not response.get("has_more") or not next_cursor:
+        if not next_cursor:
             return
 
 
@@ -78,7 +78,7 @@ async def async_iterate_paginated_api(
             yield result
 
         next_cursor = response.get("next_cursor")
-        if not response.get("has_more") or not next_cursor:
+        if not next_cursor:
             return
 
 
@@ -283,7 +283,7 @@ def iterate_data_source_templates(
             yield template  # pragma: no cover
 
         next_cursor = response.get("next_cursor")
-        if not response.get("has_more") or not next_cursor:
+        if not next_cursor:
             return
 
 
@@ -328,7 +328,7 @@ async def async_iterate_data_source_templates(
             yield template  # pragma: no cover
 
         next_cursor = response.get("next_cursor")
-        if not response.get("has_more") or not next_cursor:
+        if not next_cursor:
             return
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -583,3 +583,24 @@ async def test_async_paginator_stops_on_empty_cursor():
         if len(out) > 3:
             pytest.fail("async paginator did not terminate on an empty cursor")
     assert out == [1]
+
+
+async def test_paginators_follow_the_cursor_regardless_of_has_more():
+    """Termination is the cursor alone, as in the JS SDK's iteratePaginatedAPI."""
+    pages = [
+        {"results": [1], "has_more": False, "next_cursor": "c1"},
+        {"results": [2], "has_more": False, "next_cursor": None},
+    ]
+    seen = {"n": 0}
+
+    def sync(**kwargs):
+        page = pages[min(seen["n"], len(pages) - 1)]
+        seen["n"] += 1
+        return page
+
+    async def asyncf(**kwargs):
+        return sync(**kwargs)
+
+    assert list(iterate_paginated_api(sync)) == [1, 2]
+    seen["n"] = 0
+    assert [x async for x in async_iterate_paginated_api(asyncf)] == [1, 2]


### PR DESCRIPTION
The single PR you asked for, following #375.

`iteratePaginatedAPI` in notion-sdk-js loops on `while (nextCursor)` and never reads `has_more`. All four Python paginators required it, so a response carrying a cursor with `has_more` false stopped here and kept going there.

One line each. `iterate_paginated_api`, `async_iterate_paginated_api`, `iterate_data_source_templates` and `async_iterate_data_source_templates`.

That is four, not the three you counted, and the extra one is `async_iterate_paginated_api` from #375. Dropping the check from the other three while leaving it there would put the async paginator back out of step with the sync one, which is the thing #375 closed. It seemed worse than the wider diff, but it is one line and you should revert it if you would rather keep them separate.

Both tests from #375 still pass untouched. They turn on an empty-string cursor, which is falsy with or without the `has_more` clause, so the fix you just merged is unaffected.

Added one test for the behaviour this actually changes: a page with `has_more` false and a cursor set is now followed, in both the sync and async paginator. It fails on `main` and passes here. Suite is 195, up from 194.

I read the JS side myself instead of taking it from your comment, since this deletes a guard. `src/helpers.ts`, the `do/while (nextCursor)` loop.
