### PR TITLE
Prevent secrets in pull request tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
     - run: pip install -r requirements/tests.txt
     - run: pytest
       env:
-        NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
-    - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        NOTION_TOKEN: ${{ github.event_name == 'push' && secrets.NOTION_TOKEN || '' }}
+    - if: github.event_name == 'push'
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
       with:
         env_vars: PYTHON
         fail_ci_if_error: true


### PR DESCRIPTION
Remove Notion and Codecov secrets from pull-request execution. Live integration tests and coverage uploads continue only on trusted pushes to main, preventing PR code from accessing repository credentials.