### PR TITLE
Harden workflow permissions and action pinning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,14 @@ on:
     branches: [ main ]
     tags: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     concurrency:
       group: gh-pages
     steps:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -7,11 +7,14 @@ on:
   schedule:
     - cron: "00 7 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede  # v2.0.2
         with:
           fail: true

--- a/.github/workflows/notion-changelog-monitor.yml
+++ b/.github/workflows/notion-changelog-monitor.yml
@@ -6,9 +6,15 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:       # Enable manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   monitor-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
 


### PR DESCRIPTION
Declare least-privilege GitHub Actions permissions, grant write access only to workflows that require it, and pin the remaining mutable checkout action reference.