### PR TITLE
Read `README.md` as `UTF-8` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 def get_description():
-    with open("README.md") as file:
+    with open("README.md", encoding="utf-8") as file:
         return file.read()
 
 


### PR DESCRIPTION
`setup.py` reads `README.md` without specifying an encoding, so it falls back to the locale's preferred encoding. On systems where that isn't UTF-8 — e.g. Chinese Windows, where it is cp936/GBK — installing the package fails:

    UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 16087
    ERROR: Failed to build ... when getting requirements to build editable

README.md contains three non-ASCII characters (one emoji, two em dashes), which cp936 cannot decode. This makes `pip install -e .` (and therefore `requirements/base.txt`) fail for any contributor on a non-UTF-8 locale.

The other file readers in the repo already pass `encoding="utf-8"` (`.github/scripts/monitor_notion_changelog.py`); this brings `setup.py` in line.