### PR TITLE
Add `service_overload` (HTTP 529) retry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ These options are all keys in the single constructor parameter.
 | `timeout_ms` | `DEFAULT_TIMEOUT_MS`        | `int`             | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                    |
 | `base_url`   | `DEFAULT_BASE_URL`          | `string`          | The root URL for sending API requests. This can be changed to test with a mock server.                                                    |
 | `logger`     | Log to console              | `logging.Logger`  | A custom logger.                                                                                                                          |
-| `retry`      | See [constants](#constants) | `RetryOptions`    | Configuration for automatic retries on rate limits (429) and server errors (500, 503). See [Automatic retries](#automatic-retries) below. |
+| `retry`      | See [constants](#constants) | `RetryOptions`    | Configuration for automatic retries on rate limits (429), service overloads (529), and server errors (500, 503). See [Automatic retries](#automatic-retries) below. |
 <!-- markdownlint-enable -->
 
 ### Automatic retries
@@ -188,13 +188,15 @@ exponential back-off with jitter.
 **Retryable errors:**
 
 - `rate_limited` (HTTP 429) - Too many requests; retried for all HTTP methods
+- `service_overload` (HTTP 529) - Service overloaded; retried for all HTTP methods
 - `internal_server_error` (HTTP 500) - Server error; retried only for GET and DELETE
 - `service_unavailable` (HTTP 503) - Service temporarily unavailable;
   retried only for GET and DELETE
 
 Server errors (500, 503) are only retried for idempotent HTTP methods
-(GET, DELETE) to avoid duplicate side effects. Rate limits (429) are
-retried for all methods since the server explicitly asks clients to retry.
+(GET, DELETE) to avoid duplicate side effects. Rate limits (429) and
+service overloads (529) are retried for all methods since the server
+explicitly asks clients to retry.
 
 **Configuration:**
 

--- a/notion_client/client.py
+++ b/notion_client/client.py
@@ -246,15 +246,15 @@ class BaseClient:
     def _can_retry(self, error: Exception, method: str) -> bool:
         """Determines if an error can be retried based on its error code and method.
 
-        Rate limits (429) are always retryable since the server explicitly asks us to retry.
-        Server errors (500, 503) are only retried for idempotent methods
-        (GET, DELETE) to avoid duplicate side effects.
+        Rate limits (429) and service overloads (529) are always retryable since
+        the server explicitly asks us to retry. Server errors (500, 503) are only
+        retried for idempotent methods (GET, DELETE) to avoid duplicate side effects.
         """
         if not APIResponseError.is_api_response_error(error):
             return False
 
-        # Rate limits are always retryable - server says "try again later"
-        if error.code == APIErrorCode.RateLimited:
+        # Server says "try again later"; retry these for every HTTP method.
+        if error.code in (APIErrorCode.RateLimited, APIErrorCode.ServiceOverload):
             return True
 
         # Server errors only retry for idempotent methods

--- a/notion_client/errors.py
+++ b/notion_client/errors.py
@@ -54,6 +54,9 @@ class APIErrorCode(str, Enum):
     InternalServerError = "internal_server_error"
     """An unexpected error occurred. Reach out to Notion support."""
 
+    ServiceOverload = "service_overload"
+    """Notion is overloaded. Slow down and try again later."""
+
     ServiceUnavailable = "service_unavailable"
     """Notion is unavailable. Try again later.
     This can occur when the time to respond to a request takes longer than 60 seconds,
@@ -206,6 +209,7 @@ _http_response_error_codes: Set[str] = {
     APIErrorCode.ValidationError.value,
     APIErrorCode.ConflictError.value,
     APIErrorCode.InternalServerError.value,
+    APIErrorCode.ServiceOverload.value,
     APIErrorCode.ServiceUnavailable.value,
     APIErrorCode.GatewayTimeout.value,
 }
@@ -261,6 +265,7 @@ _api_error_codes: Set[str] = {
     APIErrorCode.ValidationError.value,
     APIErrorCode.ConflictError.value,
     APIErrorCode.InternalServerError.value,
+    APIErrorCode.ServiceOverload.value,
     APIErrorCode.ServiceUnavailable.value,
     APIErrorCode.GatewayTimeout.value,
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -49,6 +49,12 @@ def rate_limited_response(retry_after: Optional[str] = None) -> httpx.Response:
     )
 
 
+def service_overload_response(retry_after: Optional[str] = None) -> httpx.Response:
+    return _mock_http_response(
+        529, "service_overload", "Service overloaded", retry_after=retry_after
+    )
+
+
 def internal_server_error_response() -> httpx.Response:
     return _mock_http_response(500, "internal_server_error", "Internal error")
 
@@ -308,6 +314,17 @@ def test_retries_on_rate_limit_and_succeeds(mock_sleep):
 
 
 @patch("time.sleep", return_value=None)
+def test_retries_on_service_overload_and_succeeds(mock_sleep):
+    client = Client(retry=RetryOptions(max_retries=2))
+    responses = [service_overload_response(retry_after="5"), success_response()]
+    with patch.object(client.client, "send", side_effect=responses):
+        assert client.request("blocks/test", "GET") == {}
+        assert client.client.send.call_count == 2
+        mock_sleep.assert_called_once()
+        assert mock_sleep.call_args[0][0] == 5.0
+
+
+@patch("time.sleep", return_value=None)
 def test_does_not_retry_when_disabled(mock_sleep):
     client = Client(retry=False)
     with patch.object(client.client, "send", return_value=rate_limited_response()):
@@ -505,6 +522,18 @@ def test_retries_post_on_rate_limit(mock_sleep):
 
 
 @patch("time.sleep", return_value=None)
+def test_retries_post_on_service_overload(mock_sleep):
+    client = Client(retry=RetryOptions(max_retries=2, initial_retry_delay_ms=1000))
+    responses = [service_overload_response(retry_after="1"), success_response()]
+    with patch.object(client.client, "send", side_effect=responses):
+        result = client.request(
+            "pages", "POST", body={"parent": {"page_id": str(uuid.uuid4())}}
+        )
+        assert result == {}
+        assert client.client.send.call_count == 2
+
+
+@patch("time.sleep", return_value=None)
 def test_retries_delete_on_internal_server_error(mock_sleep):
     client = Client(retry=RetryOptions(max_retries=2, initial_retry_delay_ms=1000))
     responses = [internal_server_error_response(), success_response()]
@@ -537,6 +566,18 @@ async def test_async_retries_on_rate_limit_and_succeeds(mock_sleep):
     responses = [rate_limited_response(retry_after="5"), success_response()]
     with patch.object(client.client, "send", side_effect=responses):
         assert await client.request("blocks/test", "GET") == {}
+        assert client.client.send.call_count == 2
+
+
+@patch("asyncio.sleep", return_value=None)
+async def test_async_retries_post_on_service_overload(mock_sleep):
+    client = AsyncClient(retry=RetryOptions(max_retries=2, initial_retry_delay_ms=1000))
+    responses = [service_overload_response(retry_after="1"), success_response()]
+    with patch.object(client.client, "send", side_effect=responses):
+        result = await client.request(
+            "pages", "POST", body={"parent": {"page_id": str(uuid.uuid4())}}
+        )
+        assert result == {}
         assert client.client.send.call_count == 2
 
 


### PR DESCRIPTION
## Description

Adds first-class handling for `service_overload` API responses so HTTP 529 errors are parsed as `APIResponseError`s and retried using the same contract as `rate_limited` (429). 529 responses are retried for all HTTP methods and respect the `Retry-After` header.

Before this change, a 529 body fell through to `UnknownHTTPResponseError` because `service_overload` was not a known `APIErrorCode`, so it was never retried.

Aligns with makenotion/notion-sdk-js#727.
