### PR TITLE
Recognize `invalid_beta` API error code

### DIFF
--- a/notion_client/errors.py
+++ b/notion_client/errors.py
@@ -44,6 +44,10 @@ class APIErrorCode(str, Enum):
     InvalidRequest = "invalid_request"
     """This request is not supported."""
 
+    InvalidBeta = "invalid_beta"
+    """The `Notion-Beta` header is malformed, unknown, duplicated, or references a
+    stale revision."""
+
     ValidationError = "validation_error"
     """The request body does not match the schema for the expected parameters."""
 
@@ -203,6 +207,7 @@ _http_response_error_codes: Set[str] = {
     APIErrorCode.InvalidJSON.value,
     APIErrorCode.InvalidRequestURL.value,
     APIErrorCode.InvalidRequest.value,
+    APIErrorCode.InvalidBeta.value,
     APIErrorCode.ValidationError.value,
     APIErrorCode.ConflictError.value,
     APIErrorCode.InternalServerError.value,
@@ -258,6 +263,7 @@ _api_error_codes: Set[str] = {
     APIErrorCode.InvalidJSON.value,
     APIErrorCode.InvalidRequestURL.value,
     APIErrorCode.InvalidRequest.value,
+    APIErrorCode.InvalidBeta.value,
     APIErrorCode.ValidationError.value,
     APIErrorCode.ConflictError.value,
     APIErrorCode.InternalServerError.value,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -287,6 +287,31 @@ def test_build_request_error_creates_api_response_error():
         assert error.code == api_code, f"Failed for {api_code}"
 
 
+def test_build_request_error_recognizes_invalid_beta():
+    """Test that an invalid_beta error body is surfaced as an APIResponseError."""
+    body_text = """{
+        "object": "error",
+        "status": 400,
+        "code": "invalid_beta",
+        "message": "Unknown beta: foo",
+        "request_id": "abc-123-def"
+    }"""
+    response = httpx.Response(
+        status_code=400,
+        headers=httpx.Headers(),
+        content=body_text.encode(),
+    )
+    error = build_request_error(response, body_text)
+    assert isinstance(error, APIResponseError)
+    assert not isinstance(error, UnknownHTTPResponseError)
+    assert error.code == APIErrorCode.InvalidBeta
+    assert error.code.value == "invalid_beta"
+    assert error.status == 400
+    assert error.request_id == "abc-123-def"
+    assert APIResponseError.is_api_response_error(error)
+    assert is_http_response_error(error)
+
+
 def test_build_request_error_creates_unknown_http_response_error():
     """Test build_request_error creates UnknownHTTPResponseError for invalid responses."""
     response = httpx.Response(
@@ -366,7 +391,7 @@ def test_error_code_enums():
     assert APIErrorCode.Unauthorized.value == "unauthorized"
     assert APIErrorCode.ObjectNotFound.value == "object_not_found"
     assert APIErrorCode.RateLimited.value == "rate_limited"
-
+    assert APIErrorCode.InvalidBeta.value == "invalid_beta"
     assert ClientErrorCode.RequestTimeout.value == "notionhq_client_request_timeout"
     assert ClientErrorCode.ResponseError.value == "notionhq_client_response_error"
     assert (


### PR DESCRIPTION
## Description

The Notion API introduced an opt-in `Notion-Beta` request header and a matching `invalid_beta` error code (HTTP 400), returned when the header is malformed, unknown, duplicated, or references a stale revision.

Before this change, a response body with `"code": "invalid_beta"` was not a known `APIErrorCode`, so `build_request_error` fell back to `UnknownHTTPResponseError` and the `code`, `additional_data`, and `request_id` fields from the body were dropped. After this change the response is parsed as an `APIResponseError` with `error.code == APIErrorCode.InvalidBeta`, and `is_http_response_error` / `APIResponseError.is_api_response_error` recognize it.

Aligns with makenotion/notion-sdk-js#754.