### PR TITLE
Add `ray_id` and edge-proxy diagnostics to HTTP errors

### DIFF
--- a/notion_client/client.py
+++ b/notion_client/client.py
@@ -217,17 +217,17 @@ class BaseClient:
 
         return response.json()
 
-    def _extract_request_id(self, obj: Any) -> Optional[str]:
-        """Extracts request_id from an object if present."""
+    def _extract_str_field(self, obj: Any, name: str) -> Optional[str]:
+        """Extracts a string field from an object or dict if present."""
         if isinstance(obj, dict):
-            return obj.get("request_id")
+            value = obj.get(name)
         else:
-            request_id = getattr(obj, "request_id", None)
-        return request_id if isinstance(request_id, str) else None
+            value = getattr(obj, name, None)
+        return value if isinstance(value, str) else None
 
     def _log_request_success(self, method: str, path: str, response_body: Any) -> None:
         """Logs a successful request."""
-        request_id = self._extract_request_id(response_body)
+        request_id = self._extract_str_field(response_body, "request_id")
         msg = f"request success: method={method}, path={path}"
         if request_id:
             msg += f", request_id={request_id}"
@@ -235,10 +235,13 @@ class BaseClient:
 
     def _log_request_error(self, error: NotionClientError, attempt: int = 0) -> None:
         """Logs a request error with appropriate detail level."""
-        request_id = self._extract_request_id(error)
+        request_id = self._extract_str_field(error, "request_id")
+        ray_id = self._extract_str_field(error, "ray_id")
         msg = f"request fail: code={error.code}, message={error}, attempt={attempt}"
         if request_id:
             msg += f", request_id={request_id}"
+        if ray_id:
+            msg += f", ray_id={ray_id}"
         self.logger.warning(msg)
         if is_http_response_error(error):
             self.logger.debug(f"failed response body: {error.body}")

--- a/notion_client/errors.py
+++ b/notion_client/errors.py
@@ -167,6 +167,16 @@ def validate_request_path(path: str) -> None:
 HTTPResponseErrorCode = Union[ClientErrorCode, APIErrorCode]
 
 
+def _get_response_header(headers: httpx.Headers, name: str) -> Optional[str]:
+    """Reads a response header by name, or returns None when it is absent.
+
+    Header names are case-insensitive per RFC 9110, which `httpx.Headers`
+    already honors, so this only narrows the value to an optional string.
+    """
+    value = headers.get(name)
+    return value if isinstance(value, str) else None
+
+
 class HTTPResponseError(NotionClientErrorBase):
     code: Union[str, APIErrorCode]
     status: int
@@ -174,6 +184,7 @@ class HTTPResponseError(NotionClientErrorBase):
     body: str
     additional_data: Optional[Dict[str, Any]]
     request_id: Optional[str]
+    ray_id: Optional[str]  # Value of the `cf-ray` response header, when present.
 
     def __init__(
         self,
@@ -191,7 +202,10 @@ class HTTPResponseError(NotionClientErrorBase):
         self.headers = headers
         self.body = raw_body_text
         self.additional_data = additional_data
-        self.request_id = request_id
+        self.request_id = request_id or _get_response_header(
+            self.headers, "x-notion-request-id"
+        )
+        self.ray_id = _get_response_header(self.headers, "cf-ray")
 
 
 _http_response_error_codes: Set[str] = {
@@ -227,10 +241,10 @@ class UnknownHTTPResponseError(HTTPResponseError):
         headers: Optional[httpx.Headers] = None,
         raw_body_text: str = "",
     ) -> None:
-        if message is None:
-            message = f"Request to Notion API failed with status: {status}"
         if headers is None:
             headers = httpx.Headers()
+        if message is None:
+            message = _build_unknown_response_message(status, headers)
 
         super().__init__(
             code=ClientErrorCode.ResponseError.value,
@@ -239,7 +253,6 @@ class UnknownHTTPResponseError(HTTPResponseError):
             headers=headers,
             raw_body_text=raw_body_text,
             additional_data=None,
-            request_id=None,
         )
 
     @staticmethod
@@ -306,6 +319,38 @@ def build_request_error(
         headers=response.headers,
         status=response.status_code,
         raw_body_text=body_text,
+    )
+
+
+def _build_unknown_response_message(status: int, headers: httpx.Headers) -> str:
+    """Builds the default message for an unrecognized HTTP response.
+
+    A response with a Cloudflare Ray ID but no Notion request ID was answered
+    before it reached the API. The message surfaces the Ray ID rather than
+    leaving callers to infer it from an HTML body.
+    """
+    base = f"Request to Notion API failed with status: {status}"
+    ray_id = _get_response_header(headers, "cf-ray")
+    request_id = _get_response_header(headers, "x-notion-request-id")
+    answered_by_edge = ray_id is not None and request_id is None
+    if not answered_by_edge:
+        return base
+
+    content_type = _get_response_header(headers, "content-type")
+    content_type_note = (
+        f" (content-type: {content_type})" if content_type is not None else ""
+    )
+    blocked_request_note = (
+        " This may mean the request was blocked by a network security rule."
+        if status == 403
+        else ""
+    )
+    return (
+        f"{base}. The response was returned by Notion's edge proxy"
+        f" before reaching the Notion API{content_type_note}."
+        f"{blocked_request_note}"
+        f" Cloudflare Ray ID: {ray_id}."
+        " Include this ID when contacting Notion support."
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,12 @@ from unittest.mock import Mock, patch
 import httpx
 import pytest
 
-from notion_client import APIResponseError, AsyncClient, Client
+from notion_client import (
+    APIResponseError,
+    AsyncClient,
+    Client,
+    UnknownHTTPResponseError,
+)
 from notion_client.client import RetryOptions
 
 
@@ -19,22 +24,26 @@ def _mock_http_response(
     message: str = "",
     retry_after: Optional[str] = None,
     body: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    raw_content: Optional[bytes] = None,
 ) -> httpx.Response:
-    if status_code == 200:
-        response_body = body or {}
-    else:
-        response_body = {"code": code, "message": message, "object": "error"}
-        if body:
-            response_body.update(body)
-
-    headers: Dict[str, str] = {}
+    response_headers: Dict[str, str] = dict(headers or {})
     if retry_after is not None:
-        headers["retry-after"] = retry_after
+        response_headers["retry-after"] = retry_after
+
+    if raw_content is None:
+        if status_code == 200:
+            response_body = body or {}
+        else:
+            response_body = {"code": code, "message": message, "object": "error"}
+            if body:
+                response_body.update(body)
+        raw_content = json.dumps(response_body).encode()
 
     return httpx.Response(
         status_code=status_code,
-        content=json.dumps(response_body).encode(),
-        headers=headers,
+        content=raw_content,
+        headers=response_headers,
         request=httpx.Request("GET", "https://api.notion.com/v1/blocks/test"),
     )
 
@@ -278,6 +287,23 @@ def test_request_logs_success_without_request_id(client):
             client.request("/users", "GET")
 
             mock_info.assert_called_with("request success: method=GET, path=/users")
+
+
+def test_request_logs_ray_id_when_present(client):
+    """Test that a Cloudflare Ray ID on the response is logged with the failure."""
+    blocked_response = _mock_http_response(
+        403,
+        headers={"content-type": "text/html", "cf-ray": "9a1b2c3d4e5f6789-SJC"},
+        raw_content=b"<html>Access denied</html>",
+    )
+
+    with patch.object(client.client, "send", return_value=blocked_response):
+        with patch.object(client.logger, "warning") as mock_warning:
+            with pytest.raises(UnknownHTTPResponseError):
+                client.request("blocks/test", "GET")
+
+            logged = mock_warning.call_args[0][0]
+            assert "ray_id=9a1b2c3d4e5f6789-SJC" in logged
 
 
 def test_request_propagates_non_notion_error(client):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -350,15 +350,22 @@ def test_unknown_http_response_error_default_message():
     assert "503" in str(error)
     assert error.code == ClientErrorCode.ResponseError.value
     assert isinstance(error.headers, httpx.Headers)
+    assert error.request_id is None
+    assert error.ray_id is None
 
 
 def test_unknown_http_response_error_custom_message():
     """Test UnknownHTTPResponseError with custom message."""
     custom_message = "Custom error message"
-    error = UnknownHTTPResponseError(status=500, message=custom_message)
+    error = UnknownHTTPResponseError(
+        status=500,
+        message=custom_message,
+        headers=httpx.Headers({"cf-ray": "9a1b2c3d4e5f6789-SJC"}),
+    )
 
     assert error.status == 500
     assert str(error) == custom_message
+    assert error.ray_id == "9a1b2c3d4e5f6789-SJC"
 
 
 def test_error_code_enums():
@@ -496,3 +503,158 @@ def test_validate_request_path_handles_invalid_percent_encoding():
     # Python's unquote preserves invalid sequences unlike JS's decodeURIComponent
     validate_request_path("%2einvalid%2e%ZZ")
     validate_request_path("path%2ewith%invalid")
+
+
+def test_unknown_error_surfaces_edge_metadata_for_blocked_request():
+    """Test a 403 answered by the edge proxy reports the Ray ID and a likely cause."""
+    ray_id = "9a1b2c3d4e5f6789-SJC"
+    block_page_html = (
+        "<!DOCTYPE html><html><head><title>Access denied</title></head>"
+        "<body>Cloudflare Ray ID: 9a1b2c3d4e5f6789</body></html>"
+    )
+    response = httpx.Response(
+        status_code=403,
+        headers={"content-type": "text/html; charset=UTF-8", "cf-ray": ray_id},
+        content=block_page_html.encode(),
+    )
+    error = build_request_error(response, block_page_html)
+
+    assert isinstance(error, UnknownHTTPResponseError)
+    assert error.status == 403
+    assert error.ray_id == ray_id
+    assert error.request_id is None
+    message = str(error)
+    expected_edge_note = (
+        "returned by Notion's edge proxy before reaching the Notion API "
+        "(content-type: text/html; charset=UTF-8)"
+    )
+    assert expected_edge_note in message
+    assert "blocked by a network security rule" in message
+    assert f"Cloudflare Ray ID: {ray_id}" in message
+    assert error.body == block_page_html
+
+
+def test_unknown_error_reads_edge_metadata_from_mixed_case_headers():
+    """Test header names are matched case-insensitively, as HTTP requires."""
+    ray_id = "9a1b2c3d4e5f6789-SJC"
+    response = httpx.Response(
+        status_code=403,
+        headers={"Content-Type": "text/html", "CF-RAY": ray_id},
+        content=b"<html>Access denied</html>",
+    )
+    error = build_request_error(response, "<html>Access denied</html>")
+
+    assert isinstance(error, UnknownHTTPResponseError)
+    assert error.ray_id == ray_id
+    assert "(content-type: text/html)" in str(error)
+
+
+def test_unknown_error_does_not_blame_security_rule_for_server_error():
+    """Test an edge-generated 5xx describes the edge proxy without a causal claim."""
+    ray_id = "9a1b2c3d4e5f6789-SJC"
+    response = httpx.Response(
+        status_code=522,
+        headers={"content-type": "text/html; charset=UTF-8", "cf-ray": ray_id},
+        content=b"<html>Access denied</html>",
+    )
+    error = build_request_error(response, "<html>Access denied</html>")
+
+    assert isinstance(error, UnknownHTTPResponseError)
+    message = str(error)
+    assert "returned by Notion's edge proxy before reaching the Notion API" in message
+    assert "network security rule" not in message
+
+
+def test_unknown_error_omits_content_type_note_when_absent():
+    """Test an edge response without a content type still reports the Ray ID."""
+    ray_id = "9a1b2c3d4e5f6789-SJC"
+    response = httpx.Response(
+        status_code=403,
+        headers={"cf-ray": ray_id},
+        content=b"<html>Access denied</html>",
+    )
+    error = build_request_error(response, "<html>Access denied</html>")
+
+    assert isinstance(error, UnknownHTTPResponseError)
+    message = str(error)
+    assert "reaching the Notion API." in message
+    assert "content-type" not in message
+    assert f"Cloudflare Ray ID: {ray_id}" in message
+
+
+def test_unknown_error_does_not_attribute_origin_response_to_edge():
+    """Test a response with a Notion request ID keeps the generic message."""
+    ray_id = "9a1b2c3d4e5f6789-SJC"
+    body_text = '{"error": "invalid_client", "request_id": "origin-body-request-id"}'
+    response = httpx.Response(
+        status_code=401,
+        headers={
+            "content-type": "application/json; charset=utf-8",
+            "cf-ray": ray_id,
+            "x-notion-request-id": "origin-header-request-id",
+        },
+        content=body_text.encode(),
+    )
+    error = build_request_error(response, body_text)
+
+    assert isinstance(error, UnknownHTTPResponseError)
+    assert error.request_id == "origin-header-request-id"
+    assert error.ray_id == ray_id
+    assert str(error) == "Request to Notion API failed with status: 401"
+
+
+def test_unknown_error_keeps_generic_message_without_proxy_metadata():
+    """Test a response with no proxy metadata keeps the generic message."""
+    response = httpx.Response(
+        status_code=502,
+        headers={"content-type": "text/plain"},
+        content=b"upstream unavailable",
+    )
+    error = build_request_error(response, "upstream unavailable")
+
+    assert isinstance(error, UnknownHTTPResponseError)
+    assert error.request_id is None
+    assert error.ray_id is None
+    assert str(error) == "Request to Notion API failed with status: 502"
+
+
+def test_api_response_error_exposes_response_metadata():
+    """Test a well-formed Notion error keeps its message and exposes both IDs."""
+    ray_id = "9a1b2c3d4e5f6789-SJC"
+    body_text = (
+        '{"object": "error", "status": 403, "code": "restricted_resource",'
+        ' "message": "Insufficient permissions for this endpoint."}'
+    )
+    response = httpx.Response(
+        status_code=403,
+        headers={
+            "content-type": "application/json",
+            "cf-ray": ray_id,
+            "x-notion-request-id": "origin-header-request-id",
+        },
+        content=body_text.encode(),
+    )
+    error = build_request_error(response, body_text)
+
+    assert isinstance(error, APIResponseError)
+    assert error.code == APIErrorCode.RestrictedResource
+    assert str(error) == "Insufficient permissions for this endpoint."
+    assert error.request_id == "origin-header-request-id"
+    assert error.ray_id == ray_id
+
+
+def test_request_id_from_body_wins_over_header():
+    """Test a request ID in the body takes precedence over the response header."""
+    body_text = (
+        '{"code": "rate_limited", "message": "Rate limited",'
+        ' "request_id": "body-request-id"}'
+    )
+    response = httpx.Response(
+        status_code=429,
+        headers={"x-notion-request-id": "header-request-id"},
+        content=body_text.encode(),
+    )
+    error = build_request_error(response, body_text)
+
+    assert isinstance(error, APIResponseError)
+    assert error.request_id == "body-request-id"


### PR DESCRIPTION
## Description

> When a request is rejected at the network edge, the response may be HTML rather than a Notion error body. The SDK already falls back to `UnknownHTTPResponseError`, but the generic message and raw HTML do not make the failure easy to diagnose.

## Deviation from the JS port

Unlike the JS port, the failure log reads both identifiers through one generic helper. The private BaseClient._extract_request_id(obj) is renamed and generalized to BaseClient._extract_str_field(obj, name); the body is unchanged apart from taking the field name as an argument. This keeps both identifiers on one code path instead of adding an `is_http_response_error` guard in a log formatter purely to read an attribute, and it lets the two logging helpers share one extractor. 

The method is private and had no callers outside `client.py`, so the change is not a public API change.

Aligns with makenotion/notion-sdk-js#751.