### PR TITLE
Add `create` method to `blocks.meeting_notes`

### DIFF
--- a/notion_client/api_endpoints.py
+++ b/notion_client/api_endpoints.py
@@ -41,6 +41,18 @@ class BlocksChildrenEndpoint(Endpoint):
 
 
 class BlocksMeetingNotesEndpoint(Endpoint):
+    def create(self, **kwargs: Any) -> SyncAsync[Any]:
+        """Create a meeting note from a file upload or an existing block.
+
+        *[🔗 Endpoint documentation](https://developers.notion.com/reference/create-meeting-note)*
+        """  # noqa: E501
+        return self.parent.request(
+            path="blocks/meeting_notes",
+            method="POST",
+            body=pick(kwargs, "title", "language", "options", "source", "parent"),
+            auth=kwargs.get("auth"),
+        )
+
     def query(self, **kwargs: Any) -> SyncAsync[Any]:
         """Query meeting notes.
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -64,7 +64,57 @@ def test_blocks_children_list(client, page_id):
 
 
 # Meeting notes require a plan with AI meeting notes enabled, so we can't record
-# a cassette with our test integration. Using a mock instead.
+# a cassette with our test integration. Using mocks instead.
+def test_blocks_meeting_notes_create_from_file_upload(client, mocker):
+    mock_response = {"object": "block", "id": "bc2fc1d3-db8b-45c5-a222-27595b15aea7"}
+    mock_request = mocker.patch.object(client, "request", return_value=mock_response)
+
+    source = {
+        "type": "file_upload",
+        "file_upload_id": "a02fc1d3-db8b-45c5-a222-27595b15aea7",
+    }
+    parent = {"type": "page_id", "page_id": "c02fc1d3-db8b-45c5-a222-27595b15aea7"}
+
+    response = client.blocks.meeting_notes.create(
+        source=source,
+        parent=parent,
+        title="Weekly sync",
+        language="en",
+        options={"kickoff_summary": True},
+    )
+
+    assert response["object"] == "block"
+    mock_request.assert_called_once_with(
+        path="blocks/meeting_notes",
+        method="POST",
+        body={
+            "title": "Weekly sync",
+            "language": "en",
+            "options": {"kickoff_summary": True},
+            "source": source,
+            "parent": parent,
+        },
+        auth=None,
+    )
+
+
+def test_blocks_meeting_notes_create_from_block(client, mocker):
+    mock_response = {"object": "block", "id": "bc2fc1d3-db8b-45c5-a222-27595b15aea7"}
+    mock_request = mocker.patch.object(client, "request", return_value=mock_response)
+
+    source = {"type": "block", "block_id": "a02fc1d3-db8b-45c5-a222-27595b15aea7"}
+
+    response = client.blocks.meeting_notes.create(source=source)
+
+    assert response["object"] == "block"
+    mock_request.assert_called_once_with(
+        path="blocks/meeting_notes",
+        method="POST",
+        body={"source": source},
+        auth=None,
+    )
+
+
 def test_blocks_meeting_notes_query(client, mocker):
     mock_response = {"object": "list", "results": [], "has_more": False}
     mock_request = mocker.patch.object(client, "request", return_value=mock_response)


### PR DESCRIPTION
## Description

`BlocksMeetingNotesEndpoint` only exposed `query()`, so creating a meeting note required calling `client.request()` directly. This adds `client.blocks.meeting_notes.create()`, which sends a `POST` to `blocks/meeting_notes` with the `title`, `language`, `options`, `source` and `parent` body parameters.

`source` is either a file upload (`{"type": "file_upload", "file_upload_id": ...}`, which requires `parent`) or an existing audio, video or file block (`{"type": "block", "block_id": ...}`, which takes no `parent`). As everywhere else in this SDK, the parameters are passed through as-is and validated by the API rather than by the client.

Aligns with makenotion/notion-sdk-js#753.